### PR TITLE
[amazonechocontrol] fix group device not updating state

### DIFF
--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/handler/SmartHomeDeviceHandler.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/handler/SmartHomeDeviceHandler.java
@@ -18,6 +18,8 @@ import static org.smarthomej.binding.amazonechocontrol.internal.smarthome.Consta
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -168,7 +170,7 @@ public class SmartHomeDeviceHandler extends BaseThingHandler {
 
     public void updateChannelStates(List<SmartHomeBaseDevice> allDevices,
             Map<String, JsonArray> applianceIdToCapabilityStates) {
-        logger.trace("Updating {} with {}", allDevices, applianceIdToCapabilityStates);
+        logger.trace("Updating allDevices={} with states={}", allDevices, applianceIdToCapabilityStates);
         AccountHandler accountHandler = getAccountHandler();
         SmartHomeBaseDevice smartHomeBaseDevice = this.smartHomeBaseDevice;
         if (smartHomeBaseDevice == null) {
@@ -179,9 +181,11 @@ public class SmartHomeDeviceHandler extends BaseThingHandler {
         boolean stateFound = false;
         Map<String, List<JsonObject>> mapInterfaceToStates = new HashMap<>();
         SmartHomeDevice firstDevice = null;
+        logger.trace("Searching for smartHomeBaseDevice={}", smartHomeBaseDevice);
         for (SmartHomeDevice shd : getSupportedSmartHomeDevices(smartHomeBaseDevice, allDevices)) {
             String applianceId = shd.applianceId;
             if (applianceId == null) {
+                logger.trace("applianceId is null in smartHomeDevice={}", shd);
                 continue;
             }
             JsonArray states = applianceIdToCapabilityStates.get(applianceId);
@@ -192,11 +196,17 @@ public class SmartHomeDeviceHandler extends BaseThingHandler {
                     lastStates.put(applianceId, states);
                 }
             } else {
+                logger.trace("No new states array found for applianceId={}, trying to find old state.", applianceId);
                 states = lastStates.get(applianceId);
                 if (states == null) {
+                    logger.trace("No old states array found for applianceId={}, trying to find old state.",
+                            applianceId);
                     continue;
                 }
+                stateFound = true;
             }
+            logger.trace("Found states array={} for applianceId={}", states, applianceId);
+
             if (firstDevice == null) {
                 firstDevice = shd;
             }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/handler/SmartHomeDeviceHandler.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/handler/SmartHomeDeviceHandler.java
@@ -18,8 +18,6 @@ import static org.smarthomej.binding.amazonechocontrol.internal.smarthome.Consta
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeCapabilities.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeCapabilities.java
@@ -50,6 +50,11 @@ public class JsonSmartHomeCapabilities {
 
     public static class Property {
         public @Nullable String name;
+
+        @Override
+        public String toString() {
+            return "Property{" + "name='" + name + '\'' + '}';
+        }
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeCapabilities.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeCapabilities.java
@@ -33,9 +33,8 @@ public class JsonSmartHomeCapabilities {
 
         @Override
         public String toString() {
-            return "SmartHomeCapability{" + "capabilityType='" + capabilityType + '\'' + ", type='" + type + '\''
-                    + ", version='" + version + '\'' + ", interfaceName='" + interfaceName + '\'' + ", properties="
-                    + properties + '}';
+            return "SmartHomeCapability{capabilityType='" + capabilityType + "', type='" + type + "', version='"
+                    + version + "', interfaceName='" + interfaceName + "', properties=" + properties + "}";
         }
     }
 
@@ -44,7 +43,7 @@ public class JsonSmartHomeCapabilities {
 
         @Override
         public String toString() {
-            return "Properties{" + "supported=" + supported + '}';
+            return "Properties{supported=" + supported + "}";
         }
     }
 
@@ -53,13 +52,13 @@ public class JsonSmartHomeCapabilities {
 
         @Override
         public String toString() {
-            return "Property{" + "name='" + name + '\'' + '}';
+            return "Property{name='" + name + "'}";
         }
     }
 
     @Override
     public String toString() {
-        return "JsonSmartHomeCapabilities{" + "capabilites=" + capabilites + '}';
+        return "JsonSmartHomeCapabilities{capabilites=" + capabilites + "}";
     }
 
     public @Nullable List<SmartHomeCapability> capabilites;

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeDeviceAlias.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeDeviceAlias.java
@@ -26,6 +26,6 @@ public class JsonSmartHomeDeviceAlias {
 
     @Override
     public String toString() {
-        return "JsonSmartHomeDeviceAlias{" + "friendlyName='" + friendlyName + '\'' + ", enabled=" + enabled + '}';
+        return "JsonSmartHomeDeviceAlias{friendlyName='" + friendlyName + "', enabled=" + enabled + "}";
     }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeDeviceAlias.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeDeviceAlias.java
@@ -24,11 +24,8 @@ public class JsonSmartHomeDeviceAlias {
     public @Nullable String friendlyName;
     public @Nullable Boolean enabled;
 
-    public JsonSmartHomeDeviceAlias(String friendlyName, Boolean enabled) {
-        this.friendlyName = friendlyName;
-        this.enabled = enabled;
-    }
-
-    public JsonSmartHomeDeviceAlias() {
+    @Override
+    public String toString() {
+        return "JsonSmartHomeDeviceAlias{" + "friendlyName='" + friendlyName + '\'' + ", enabled=" + enabled + '}';
     }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeDeviceNetworkState.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeDeviceNetworkState.java
@@ -28,7 +28,7 @@ public class JsonSmartHomeDeviceNetworkState {
 
         @Override
         public String toString() {
-            return "SmartHomeDeviceNetworkState{" + "reachability='" + reachability + '\'' + '}';
+            return "SmartHomeDeviceNetworkState{reachability='" + reachability + "'}";
         }
     }
 
@@ -36,6 +36,6 @@ public class JsonSmartHomeDeviceNetworkState {
 
     @Override
     public String toString() {
-        return "JsonSmartHomeDeviceNetworkState{" + "networkState=" + networkState + '}';
+        return "JsonSmartHomeDeviceNetworkState{networkState=" + networkState + "}";
     }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeDeviceNetworkState.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeDeviceNetworkState.java
@@ -25,7 +25,17 @@ import org.eclipse.jdt.annotation.Nullable;
 public class JsonSmartHomeDeviceNetworkState {
     public static class SmartHomeDeviceNetworkState {
         public @Nullable String reachability;
+
+        @Override
+        public String toString() {
+            return "SmartHomeDeviceNetworkState{" + "reachability='" + reachability + '\'' + '}';
+        }
     }
 
     public @Nullable SmartHomeDeviceNetworkState networkState;
+
+    @Override
+    public String toString() {
+        return "JsonSmartHomeDeviceNetworkState{" + "networkState=" + networkState + '}';
+    }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroupIdentifiers.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroupIdentifiers.java
@@ -24,7 +24,17 @@ public class JsonSmartHomeGroupIdentifiers {
 
     public static class SmartHomeGroupIdentifier {
         public @Nullable String value;
+
+        @Override
+        public String toString() {
+            return "SmartHomeGroupIdentifier{" + "value='" + value + '\'' + '}';
+        }
     }
 
     public @Nullable SmartHomeGroupIdentifier identifier;
+
+    @Override
+    public String toString() {
+        return "JsonSmartHomeGroupIdentifiers{" + "identifier=" + identifier + '}';
+    }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroupIdentifiers.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroupIdentifiers.java
@@ -27,7 +27,7 @@ public class JsonSmartHomeGroupIdentifiers {
 
         @Override
         public String toString() {
-            return "SmartHomeGroupIdentifier{" + "value='" + value + '\'' + '}';
+            return "SmartHomeGroupIdentifier{value='" + value + "'}";
         }
     }
 
@@ -35,6 +35,6 @@ public class JsonSmartHomeGroupIdentifiers {
 
     @Override
     public String toString() {
-        return "JsonSmartHomeGroupIdentifiers{" + "identifier=" + identifier + '}';
+        return "JsonSmartHomeGroupIdentifiers{identifier=" + identifier + "}";
     }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroupIdentity.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroupIdentity.java
@@ -30,7 +30,7 @@ public class JsonSmartHomeGroupIdentity {
 
         @Override
         public String toString() {
-            return "SmartHomeGroupIdentity{" + "groupIdentity=" + groupIdentity + '}';
+            return "SmartHomeGroupIdentity{groupIdentity=" + groupIdentity + "}";
         }
     }
 
@@ -38,6 +38,6 @@ public class JsonSmartHomeGroupIdentity {
 
     @Override
     public String toString() {
-        return "JsonSmartHomeGroupIdentity{" + "groupIdentity=" + groupIdentity + '}';
+        return "JsonSmartHomeGroupIdentity{groupIdentity=" + groupIdentity + "}";
     }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroupIdentity.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroupIdentity.java
@@ -27,7 +27,17 @@ import org.eclipse.jdt.annotation.Nullable;
 public class JsonSmartHomeGroupIdentity {
     public static class SmartHomeGroupIdentity {
         public @Nullable List<String> groupIdentity;
+
+        @Override
+        public String toString() {
+            return "SmartHomeGroupIdentity{" + "groupIdentity=" + groupIdentity + '}';
+        }
     }
 
     public @Nullable List<SmartHomeGroupIdentity> groupIdentity;
+
+    @Override
+    public String toString() {
+        return "JsonSmartHomeGroupIdentity{" + "groupIdentity=" + groupIdentity + '}';
+    }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroups.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroups.java
@@ -58,4 +58,9 @@ public class JsonSmartHomeGroups {
     }
 
     public @Nullable List<SmartHomeGroup> groups;
+
+    @Override
+    public String toString() {
+        return "JsonSmartHomeGroups{" + "groups=" + groups + '}';
+    }
 }

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroups.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/jsons/JsonSmartHomeGroups.java
@@ -52,8 +52,8 @@ public class JsonSmartHomeGroups {
 
         @Override
         public String toString() {
-            return "SmartHomeGroup{" + "applianceGroupName='" + applianceGroupName + '\'' + ", isSpace=" + isSpace
-                    + ", space=" + space + ", applianceGroupIdentifier=" + applianceGroupIdentifier + '}';
+            return "SmartHomeGroup{applianceGroupName='" + applianceGroupName + "', isSpace=" + isSpace + ", space="
+                    + space + ", applianceGroupIdentifier=" + applianceGroupIdentifier + "}";
         }
     }
 
@@ -61,6 +61,6 @@ public class JsonSmartHomeGroups {
 
     @Override
     public String toString() {
-        return "JsonSmartHomeGroups{" + "groups=" + groups + '}';
+        return "JsonSmartHomeGroups{groups=" + groups + "}";
     }
 }


### PR DESCRIPTION
Should fix the issue reported in https://community.openhab.org/t/amazonechocontrol-cycles-rapidly-between-unknown-and-online-snapshot-3-1-binding/115811 and improves debug logging in case it does not.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>