### PR TITLE
[androiddebugbridge] add fallback to start package channel

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -19,6 +19,7 @@ import static org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBri
 import static org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBridgeBindingConstants.MEDIA_CONTROL_CHANNEL;
 import static org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBridgeBindingConstants.MEDIA_VOLUME_CHANNEL;
 import static org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBridgeBindingConstants.SCREEN_STATE_CHANNEL;
+import static org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBridgeBindingConstants.START_PACKAGE_CHANNEL;
 import static org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBridgeBindingConstants.WAKE_LOCK_CHANNEL;
 
 import java.io.*;
@@ -31,6 +32,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.*;
@@ -86,7 +88,7 @@ public class AndroidDebugBridgeDevice {
     private String ip = "127.0.0.1";
     private int port = 5555;
     private int timeoutSec = 5;
-    private boolean fallbackStartPackage = false;
+    private HashMap<String, FallbackModes> channelFallbackMap = new HashMap<>();
     private @Nullable Socket socket;
     private @Nullable AdbConnection connection;
     private @Nullable Future<String> commandFuture;
@@ -127,13 +129,13 @@ public class AndroidDebugBridgeDevice {
             logger.warn("{} is not a valid package name", packageName);
             return;
         }
-        if (fallbackStartPackage) {
+        if (channelFallbackMap.get(START_PACKAGE_CHANNEL) == FallbackModes.MONKEY) {
             startPackageWithMonkey(packageName);
             return;
         }
         String output = runAdbShell("am", "start", "-n", packageName);
         if (output.contains("usage: am")) {
-            fallbackStartPackage = true;
+            channelFallbackMap.put(START_PACKAGE_CHANNEL, FallbackModes.MONKEY);
             startPackageWithMonkey(packageName);
         }
     }
@@ -145,6 +147,10 @@ public class AndroidDebugBridgeDevice {
 
     public void stopPackage(String packageName)
             throws AndroidDebugBridgeDeviceException, InterruptedException, TimeoutException, ExecutionException {
+        if (!PACKAGE_NAME_PATTERN.matcher(packageName).matches()) {
+            logger.warn("{} is not a valid package name", packageName);
+            return;
+        }
         runAdbShell("am", "force-stop", packageName);
     }
 
@@ -166,73 +172,74 @@ public class AndroidDebugBridgeDevice {
         throw new AndroidDebugBridgeDeviceReadException(CURRENT_PACKAGE_CHANNEL, result);
     }
 
-    public Optional<Boolean> isAwake() throws InterruptedException, AndroidDebugBridgeDeviceException,
+    public boolean isAwake() throws InterruptedException, AndroidDebugBridgeDeviceException,
             AndroidDebugBridgeDeviceReadException, TimeoutException, ExecutionException {
         String result = runAdbShell("dumpsys", "activity", "|", "grep", "mWakefulness");
         if (result.contains("mWakefulness=")) {
-            return Optional.of(result.contains("mWakefulness=Awake"));
-        } else if (result.isEmpty()) {
-            return Optional.empty();
+            return result.contains("mWakefulness=Awake");
         }
         throw new AndroidDebugBridgeDeviceReadException(AWAKE_STATE_CHANNEL, result);
     }
 
-    public Optional<Boolean> isScreenOn() throws InterruptedException, AndroidDebugBridgeDeviceException,
+    public boolean isScreenOn() throws InterruptedException, AndroidDebugBridgeDeviceException,
             AndroidDebugBridgeDeviceReadException, TimeoutException, ExecutionException {
         String result = runAdbShell("dumpsys", "power", "|", "grep", "'Display Power'");
         String[] splitResult = result.split("=");
         if (splitResult.length >= 2) {
-            return Optional.of("ON".equals(splitResult[1]));
-        } else if (result.isEmpty()) {
-            return Optional.empty();
+            "ON".equals(splitResult[1]);
         }
         throw new AndroidDebugBridgeDeviceReadException(SCREEN_STATE_CHANNEL, result);
     }
 
     public Optional<Boolean> isHDMIOn() throws InterruptedException, AndroidDebugBridgeDeviceException,
             AndroidDebugBridgeDeviceReadException, TimeoutException, ExecutionException {
+        if (channelFallbackMap.get(HDMI_STATE_CHANNEL) == FallbackModes.LOGCAT) {
+            return isHDMIOnWithLogcat();
+        }
         String result = runAdbShell("cat", "/sys/devices/virtual/switch/hdmi/state");
         if (result.equals("0") || result.equals("1")) {
             return Optional.of(result.equals("1"));
-        } else if (result.isEmpty()) {
-            return Optional.empty();
         } else {
-            String fallback = runAdbShell("logcat", "-d", "|", "grep", "hdmi", "|", "grep", "SWITCH_STATE=", "|",
-                    "tail", "-1");
-            if (fallback.contains("SWITCH_STATE=")) {
-                return Optional.of(fallback.contains("SWITCH_STATE=1"));
-            } else if (fallback.isEmpty()) {
-                return Optional.empty();
-            }
-            throw new AndroidDebugBridgeDeviceReadException(HDMI_STATE_CHANNEL, result, fallback);
+            channelFallbackMap.put(HDMI_STATE_CHANNEL, FallbackModes.LOGCAT);
+            return isHDMIOnWithLogcat();
         }
     }
 
-    public Optional<Boolean> isPlayingMedia(String currentApp) throws AndroidDebugBridgeDeviceException,
+    private Optional<Boolean> isHDMIOnWithLogcat() throws InterruptedException, AndroidDebugBridgeDeviceException,
+            AndroidDebugBridgeDeviceReadException, TimeoutException, ExecutionException {
+        String result = runAdbShell("logcat", "-d", "|", "grep", "hdmi", "|", "grep", "SWITCH_STATE=", "|", "tail",
+                "-1");
+        if (result.contains("SWITCH_STATE=")) {
+            return Optional.of(result.contains("SWITCH_STATE=1"));
+        } else if (result.isEmpty()) {
+            // IF THE DEVICE DO NOT SUPPORT THIS VALUE IN LOGCAT THE USER WILL NEVER KNOW THE CHANNEL WON'T WORK
+            // FIND A BETTER SOLUTION
+            return Optional.empty();
+        }
+        throw new AndroidDebugBridgeDeviceReadException(HDMI_STATE_CHANNEL, result);
+    }
+
+    public boolean isPlayingMedia(String currentApp) throws AndroidDebugBridgeDeviceException,
             AndroidDebugBridgeDeviceReadException, InterruptedException, TimeoutException, ExecutionException {
         String result = runAdbShell("dumpsys", "media_session", "|", "grep", "-A", "100", "'Sessions Stack'", "|",
                 "grep", "-A", "50", currentApp);
         String[] mediaSessions = result.split("\n\n");
         if (mediaSessions.length == 0) {
             // no media session found for current app
-            return Optional.of(false);
+            return false;
         } else if (mediaSessions[0].contains("PlaybackState {state=3")) {
             boolean isPlaying = mediaSessions[0].contains("PlaybackState {state=3");
             logger.debug("device media state playing {}", isPlaying);
-            return Optional.of(isPlaying);
-        } else if (result.isEmpty()) {
-            return Optional.empty();
+            return isPlaying;
         }
         throw new AndroidDebugBridgeDeviceReadException(MEDIA_CONTROL_CHANNEL, result);
     }
 
-    public Optional<Boolean> isPlayingAudio() throws AndroidDebugBridgeDeviceException,
-            AndroidDebugBridgeDeviceReadException, InterruptedException, TimeoutException, ExecutionException {
+    public boolean isPlayingAudio() throws AndroidDebugBridgeDeviceException, AndroidDebugBridgeDeviceReadException,
+            InterruptedException, TimeoutException, ExecutionException {
         String result = runAdbShell("dumpsys", "audio", "|", "grep", "ID:");
         if (result.contains("state:")) {
-            return Optional.of(result.contains("state:started"));
-        } else if (result.isEmpty()) {
-            return Optional.empty();
+            return result.contains("state:started");
         }
         throw new AndroidDebugBridgeDeviceReadException(MEDIA_CONTROL_CHANNEL, result);
     }
@@ -444,5 +451,10 @@ public class AndroidDebugBridgeDevice {
             this.min = min;
             this.max = max;
         }
+    }
+
+    private enum FallbackModes {
+        MONKEY,
+        LOGCAT,
     }
 }

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -33,6 +33,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.*;
@@ -88,7 +89,7 @@ public class AndroidDebugBridgeDevice {
     private String ip = "127.0.0.1";
     private int port = 5555;
     private int timeoutSec = 5;
-    private HashMap<String, FallbackModes> channelFallbackMap = new HashMap<>();
+    private Map<String, FallbackModes> channelFallbackMap = new HashMap<>();
     private @Nullable Socket socket;
     private @Nullable AdbConnection connection;
     private @Nullable Future<String> commandFuture;

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -216,6 +216,7 @@ public class AndroidDebugBridgeDevice {
             // FIND A BETTER SOLUTION
             return Optional.empty();
         }
+        channelFallbackMap.remove(HDMI_STATE_CHANNEL);
         throw new AndroidDebugBridgeDeviceReadException(HDMI_STATE_CHANNEL, result);
     }
 

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -17,7 +17,6 @@ import static org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBri
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -62,7 +61,6 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     private AndroidDebugBridgeConfiguration config = new AndroidDebugBridgeConfiguration();
     private @Nullable ScheduledFuture<?> connectionCheckerSchedule;
     private AndroidDebugBridgeMediaStatePackageConfig @Nullable [] packageConfigs = null;
-    private boolean deviceAwake = false;
 
     public AndroidDebugBridgeHandler(Thing thing) {
         super(thing);
@@ -141,24 +139,22 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                 break;
             case CURRENT_PACKAGE_CHANNEL:
                 if (command instanceof RefreshType) {
-                    String packageName = adbConnection.getCurrentPackage();
-                    updateState(channelUID, new StringType(packageName));
+                    updateState(channelUID, new StringType(adbConnection.getCurrentPackage()));
                 }
                 break;
             case WAKE_LOCK_CHANNEL:
                 if (command instanceof RefreshType) {
-                    int lock = adbConnection.getPowerWakeLock();
-                    updateState(channelUID, new DecimalType(lock));
+                    updateState(channelUID, new DecimalType(adbConnection.getPowerWakeLock()));
                 }
                 break;
             case AWAKE_STATE_CHANNEL:
                 if (command instanceof RefreshType) {
-                    adbConnection.isAwake().ifPresent(state -> updateState(channelUID, OnOffType.from(state)));
+                    updateState(channelUID, OnOffType.from(adbConnection.isAwake()));
                 }
                 break;
             case SCREEN_STATE_CHANNEL:
                 if (command instanceof RefreshType) {
-                    adbConnection.isScreenOn().ifPresent(state -> updateState(channelUID, OnOffType.from(state)));
+                    updateState(channelUID, OnOffType.from(adbConnection.isScreenOn()));
                 }
                 break;
             case HDMI_STATE_CHANNEL:
@@ -198,7 +194,7 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             throws InterruptedException, AndroidDebugBridgeDeviceException, AndroidDebugBridgeDeviceReadException,
             TimeoutException, ExecutionException {
         if (command instanceof RefreshType) {
-            Optional<Boolean> playing;
+            boolean playing;
             String currentPackage = adbConnection.getCurrentPackage();
             AndroidDebugBridgeMediaStatePackageConfig currentPackageConfig = packageConfigs != null ? Arrays
                     .stream(packageConfigs).filter(pc -> pc.name.equals(currentPackage)).findFirst().orElse(null)
@@ -207,11 +203,11 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                 logger.debug("media stream config found for {}, mode: {}", currentPackage, currentPackageConfig.mode);
                 switch (currentPackageConfig.mode) {
                     case "idle":
-                        playing = Optional.of(false);
+                        playing = false;
                         break;
                     case "wake_lock":
                         int wakeLockState = adbConnection.getPowerWakeLock();
-                        playing = Optional.of(currentPackageConfig.wakeLockPlayStates.contains(wakeLockState));
+                        playing = currentPackageConfig.wakeLockPlayStates.contains(wakeLockState);
                         break;
                     case "media_state":
                         playing = adbConnection.isPlayingMedia(currentPackage);
@@ -221,13 +217,13 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                         break;
                     default:
                         logger.warn("media state config: package {} unsupported mode", currentPackage);
-                        playing = Optional.of(false);
+                        playing = false;
                 }
             } else {
                 logger.debug("media stream config not found for {}", currentPackage);
                 playing = adbConnection.isPlayingMedia(currentPackage);
             }
-            updateState(channelUID, playing.isPresent() && playing.get() ? PlayPauseType.PLAY : PlayPauseType.PAUSE);
+            updateState(channelUID, playing ? PlayPauseType.PLAY : PlayPauseType.PAUSE);
         } else if (command instanceof PlayPauseType) {
             if (command == PlayPauseType.PLAY) {
                 adbConnection.sendKeyEvent(KEY_EVENT_PLAY);
@@ -378,6 +374,15 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
             logger.warn("Unable to refresh screen state: {}", e.getMessage());
         } catch (TimeoutException e) {
             logger.debug("Unable to refresh screen state: Timeout");
+            adbConnection.disconnect();
+            return;
+        }
+        try {
+            handleCommandInternal(new ChannelUID(this.thing.getUID(), HDMI_STATE_CHANNEL), RefreshType.REFRESH);
+        } catch (AndroidDebugBridgeDeviceReadException e) {
+            logger.warn("Unable to refresh hdmi state: {}", e.getMessage());
+        } catch (TimeoutException e) {
+            logger.debug("Unable to refresh hdmi state: Timeout");
             adbConnection.disconnect();
             return;
         }


### PR DESCRIPTION
Add fallback to the start package channel, using monkey command to open applications instead of am on devices which doesn't support the -n parameter (devices under android 8).