### PR TITLE
[androiddebugbridge] missing return of the method

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -160,7 +160,7 @@ public class AndroidDebugBridgeDevice {
         String result = runAdbShell("dumpsys", "power", "|", "grep", "'Display Power'");
         String[] splitResult = result.split("=");
         if (splitResult.length >= 2) {
-            "ON".equals(splitResult[1]);
+            return "ON".equals(splitResult[1]);
         }
         throw new AndroidDebugBridgeDeviceReadException(SCREEN_STATE_CHANNEL, result);
     }


### PR DESCRIPTION
added: missing return of the method (accidentally removed)

Signed-off-by: Tom Blum <trinitus01@googlemail.com>