### PR TITLE
[androiddebugbridge] shutdown channel, naming and improvements

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/README.md
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/README.md
@@ -56,15 +56,16 @@ This is a sample of the mediaStateJSONConfig thing configuration:
 
 | channel  | type   | description                  |
 |----------|--------|------------------------------|
-| mouse-tap  | String | Send mouse tap to android device. With the pattern x,y |
 | key-event  | String | Send key event to android device. Possible values listed below |
 | text  | String | Send text to android device |
+| tap  | String | Send tap event to android device (format x,y) |
 | media-volume  | Dimmer | Set or get media volume level on android device |
 | media-control  | Player | Control media on android device |
 | start-package  | String | Run application by package name |
 | stop-package  | String | Stop application by package name |
 | stop-open-url  | String | Open a URL with the default application (http, rtsp, aso) |
 | current-package  | String | Package name of the top application in screen |
+| shutdown  | String | Power off/reboot device (allowed values POWER_OFF, REBOOT) |
 | wake-lock  | Number | Power wake lock value |
 | screen-state  | Switch | Screen power state |
 | hdmi-state  | Switch | HDMI power state |

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeBindingConstants.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeBindingConstants.java
@@ -35,9 +35,9 @@ public class AndroidDebugBridgeBindingConstants {
     public static final ThingTypeUID THING_TYPE_ANDROID_DEVICE = new ThingTypeUID(BINDING_ID, "android");
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_ANDROID_DEVICE);
     // List of all Channel ids
-    public static final String MOUSE_TAP_CHANNEL = "mouse-tap";
     public static final String KEY_EVENT_CHANNEL = "key-event";
     public static final String TEXT_CHANNEL = "text";
+    public static final String TAP_CHANNEL = "tap";
     public static final String MEDIA_VOLUME_CHANNEL = "media-volume";
     public static final String MEDIA_CONTROL_CHANNEL = "media-control";
     public static final String START_PACKAGE_CHANNEL = "start-package";
@@ -45,10 +45,12 @@ public class AndroidDebugBridgeBindingConstants {
     public static final String STOP_CURRENT_PACKAGE_CHANNEL = "stop-current-package";
     public static final String OPEN_URL_CHANNEL = "open-url";
     public static final String CURRENT_PACKAGE_CHANNEL = "current-package";
+    public static final String SHUTDOWN_CHANNEL = "shutdown";
     public static final String AWAKE_STATE_CHANNEL = "awake-state";
     public static final String WAKE_LOCK_CHANNEL = "wake-lock";
     public static final String SCREEN_STATE_CHANNEL = "screen-state";
     public static final String HDMI_STATE_CHANNEL = "hdmi-state";
+
     // List of all Parameters
     public static final String PARAMETER_IP = "ip";
     public static final String PARAMETER_PORT = "port";

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -60,6 +60,8 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
     public static final String KEY_EVENT_PREVIOUS = "88";
     public static final String KEY_EVENT_MEDIA_REWIND = "89";
     public static final String KEY_EVENT_MEDIA_FAST_FORWARD = "90";
+    private static final String SHUTDOWN_POWER_OFF = "POWER_OFF";
+    private static final String SHUTDOWN_REBOOT = "REBOOT";
     private static final Gson GSON = new Gson();
     private final Logger logger = LoggerFactory.getLogger(AndroidDebugBridgeHandler.class);
     private final AndroidDebugBridgeDevice adbConnection;
@@ -106,14 +108,14 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
         }
         String channelId = channelUID.getId();
         switch (channelId) {
-            case MOUSE_TAP_CHANNEL:
-                adbConnection.sendMouseTap(command.toFullString());
-                break;
             case KEY_EVENT_CHANNEL:
                 adbConnection.sendKeyEvent(command.toFullString());
                 break;
             case TEXT_CHANNEL:
                 adbConnection.sendText(command.toFullString());
+                break;
+            case TAP_CHANNEL:
+                adbConnection.sendTap(command.toFullString());
                 break;
             case MEDIA_VOLUME_CHANNEL:
                 handleMediaVolume(channelUID, command);
@@ -148,6 +150,17 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                     updateState(channelUID, new StringType(adbConnection.getCurrentPackage()));
                 }
                 break;
+            case SHUTDOWN_CHANNEL:
+                switch (command.toFullString()) {
+                    case SHUTDOWN_POWER_OFF:
+                        adbConnection.powerOffDevice();
+                        updateStatus(ThingStatus.OFFLINE);
+                        break;
+                    case SHUTDOWN_REBOOT:
+                        adbConnection.rebootDevice();
+                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.GONE, "Rebooting");
+                        break;
+                }
             case WAKE_LOCK_CHANNEL:
                 if (command instanceof RefreshType) {
                     updateState(channelUID, new DecimalType(adbConnection.getPowerWakeLock()));

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
@@ -8,9 +8,9 @@
 		<label>Android Device Thing</label>
 		<description>Android Device Thing for Android Debug Bridge Binding</description>
 		<channels>
-			<channel id="mouse-tap" typeId="mouse-tap-channel"/>
 			<channel id="key-event" typeId="key-event-channel"/>
 			<channel id="text" typeId="text-channel"/>
+			<channel id="tap" typeId="tap-channel"/>
 			<channel id="media-volume" typeId="system.volume"/>
 			<channel id="media-control" typeId="system.media-control"/>
 			<channel id="start-package" typeId="start-package-channel"/>
@@ -22,6 +22,7 @@
 			<channel id="screen-state" typeId="screen-state-channel"/>
 			<channel id="awake-state" typeId="awake-state-channel"/>
 			<channel id="hdmi-state" typeId="hdmi-state-channel"/>
+			<channel id="shutdown" typeId="shutdown-channel"/>
 		</channels>
 		<representation-property>serial</representation-property>
 		<config-description>
@@ -52,12 +53,6 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-
-	<channel-type id="mouse-tap-channel">
-		<item-type>String</item-type>
-		<label>Send Mouse Tap</label>
-		<description>Send mouse tap to android device</description>
-	</channel-type>
 
 	<channel-type id="key-event-channel">
 		<item-type>String</item-type>
@@ -364,6 +359,12 @@
 		<description>Send text to android device</description>
 	</channel-type>
 
+	<channel-type id="tap-channel">
+		<item-type>String</item-type>
+		<label>Send Tap</label>
+		<description>Send tap to android device</description>
+	</channel-type>
+
 	<channel-type id="start-package-channel">
 		<item-type>String</item-type>
 		<label>Start Package</label>
@@ -393,6 +394,18 @@
 		<label>Current Package</label>
 		<description>Package name of the top application in screen</description>
 		<state readOnly="true"/>
+	</channel-type>
+
+	<channel-type id="shutdown-channel" advanced="true">
+		<item-type>String</item-type>
+		<label>Shutdown</label>
+		<description>Shutdown/Reboot Device</description>
+		<state>
+			<options>
+				<option value="POWER_OFF">POWER_OFF</option>
+				<option value="REBOOT">REBOOT</option>
+			</options>
+		</state>
 	</channel-type>
 
 	<channel-type id="wake-lock-channel" advanced="true">


### PR DESCRIPTION
ported: shutdown channel
ported: tap event pattern
ported: some variable names
changed: mouse-tap channel to tap channel
changed: package name pattern for extended package names

ported from: https://github.com/openhab/openhab-addons/pull/10497

Also-By: Miguel <miguelwork92@gmail.com>
Signed-off-by: Tom Blum <trinitus01@googlemail.com>