### PR TITLE
[knx] upgrade calimero and improve documentation

### DIFF
--- a/bundles/org.smarthomej.binding.knx/README.md
+++ b/bundles/org.smarthomej.binding.knx/README.md
@@ -15,10 +15,6 @@ Since the protocol is identical, the KNX binding can also communicate with it tr
 The KNX binding supports two types of bridges, and one type of things to access the KNX bus.
 There is an *ip* bridge to connect to KNX IP Gateways, and a *serial* bridge for connection over a serial port to a host-attached gateway.
 
-## Binding Configuration
-
-The binding itself does not require any special configuration.
-
 ## Bridges
 
 The following two bridge types are supported. Bridges don't have channels on their own.
@@ -110,6 +106,9 @@ Note: After changing the DPT of already existing Channels, openHAB needs to be r
 |-----------|---------------|-------------|
 | ga        | Group address | 1.009       |
 
+*Attention:* Due to a bug in the original implementation the states for DPT 1.009 are inverted (i.e. `1` is mapped to `OPEN` instead of `CLOSE`). 
+A change would break all existing installations and is therefore not implemented.
+
 ##### Channel Type "number"
 
 | Parameter | Description   | Default DPT |
@@ -164,6 +163,9 @@ If from the KNX bus a `GroupValueRead` telegram is sent to a *-control Channel, 
 | Parameter | Description   | Default DPT |
 |-----------|---------------|-------------|
 | ga        | Group address | 1.009       |
+
+*Attention:* Due to a bug in the original implementation the states for DPT 1.009 are inverted (i.e. `1` is mapped to `OPEN` instead of `CLOSE`).
+A change would break all existing installations and is therefore not implemented.
 
 ##### Channel Type "number-control"
 

--- a/bundles/org.smarthomej.binding.knx/pom.xml
+++ b/bundles/org.smarthomej.binding.knx/pom.xml
@@ -16,13 +16,14 @@
 
   <properties>
     <bnd.importpackage>gnu.io;version="[3.12,6)",javax.microedition.io.*;resolution:="optional",javax.usb.*;resolution:="optional",org.usb4java.*;resolution:="optional"</bnd.importpackage>
+    <calimero.version>2.5-M1</calimero.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.github.calimero</groupId>
       <artifactId>calimero-core</artifactId>
-      <version>2.4</version>
+      <version>${calimero.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -34,7 +35,7 @@
     <dependency>
       <groupId>com.github.calimero</groupId>
       <artifactId>calimero-device</artifactId>
-      <version>2.4</version>
+      <version>${calimero.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -46,7 +47,7 @@
     <dependency>
       <groupId>com.github.calimero</groupId>
       <artifactId>calimero-rxtx</artifactId>
-      <version>2.4</version>
+      <version>${calimero.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/client/AbstractKNXClient.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/client/AbstractKNXClient.java
@@ -49,11 +49,13 @@ import tuwien.auto.calimero.mgmt.ManagementClient;
 import tuwien.auto.calimero.mgmt.ManagementClientImpl;
 import tuwien.auto.calimero.mgmt.ManagementProcedures;
 import tuwien.auto.calimero.mgmt.ManagementProceduresImpl;
-import tuwien.auto.calimero.process.ProcessCommunicationBase;
+import tuwien.auto.calimero.process.ProcessCommunication;
 import tuwien.auto.calimero.process.ProcessCommunicator;
 import tuwien.auto.calimero.process.ProcessCommunicatorImpl;
 import tuwien.auto.calimero.process.ProcessEvent;
 import tuwien.auto.calimero.process.ProcessListener;
+import tuwien.auto.calimero.secure.SecureApplicationLayer;
+import tuwien.auto.calimero.secure.Security;
 
 /**
  * KNX Client which encapsulates the communication with the KNX bus via the calimero libary.
@@ -192,7 +194,8 @@ public abstract class AbstractKNXClient implements NetworkLinkListener, KNXClien
             processCommunicator.addProcessListener(processListener);
             this.processCommunicator = processCommunicator;
 
-            ProcessCommunicationResponder responseCommunicator = new ProcessCommunicationResponder(link);
+            ProcessCommunicationResponder responseCommunicator = new ProcessCommunicationResponder(link,
+                    new SecureApplicationLayer(link, Security.defaultInstallation()));
             this.responseCommunicator = responseCommunicator;
 
             link.addLinkListener(this);
@@ -439,7 +442,7 @@ public abstract class AbstractKNXClient implements NetworkLinkListener, KNXClien
         }
     }
 
-    private void sendToKNX(ProcessCommunicationBase communicator, KNXNetworkLink link, GroupAddress groupAddress,
+    private void sendToKNX(ProcessCommunication communicator, KNXNetworkLink link, GroupAddress groupAddress,
             String dpt, Type type) throws KNXException {
         if (!connectIfNotAutomatic()) {
             return;


### PR DESCRIPTION
This upgrades calimero from  2.4 to 2.5-M1. Although this is not a final release, it's permanently available on Maven Central. The upgrade is required to enable KNX secure in a second step and also support newer DPT.