### PR TITLE
[http] allow setting custom User-Agent header

### DIFF
--- a/bundles/org.smarthomej.binding.http/README.md
+++ b/bundles/org.smarthomej.binding.http/README.md
@@ -25,8 +25,9 @@ It can be extended with different channels.
 | `encoding`        | yes      |    -    | Encoding to be used if no encoding is found in responses (advanced parameter). |  
 | `headers`         | yes      |    -    | Additional headers that are sent along with the request. Format is "header=value". Multiple values can be stored as `headers="key1=value1", "key2=value2", "key3=value3",`| 
 | `ignoreSSLErrors` | no       |  false  | If set to true ignores invalid SSL certificate errors. This is potentially dangerous.|
+| `userAgent`       | yes      |   yes   | Sets a custom user agent (default is "Jetty/version", e.g. "Jetty/9.4.20.v20190813"). |
 
-*Note:* Optional "no" means that you have to configure a value unless a default is provided and you are ok with that setting.
+*Note:* Optional "no" means that you have to configure a value unless a default is provided, and you are ok with that setting.
 
 *Note:* The `BASIC_PREEMPTIVE` mode adds basic authentication headers even if the server did not request authentication.
 This is dangerous and might be misused.

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpHandlerFactory.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpHandlerFactory.java
@@ -13,7 +13,7 @@
  */
 package org.smarthomej.binding.http.internal;
 
-import static org.smarthomej.binding.http.internal.HttpBindingConstants.*;
+import static org.smarthomej.binding.http.internal.HttpBindingConstants.THING_TYPE_URL;
 
 import java.util.Set;
 
@@ -61,13 +61,16 @@ public class HttpHandlerFactory extends BaseThingHandlerFactory implements HttpC
         this.secureClient = new HttpClient(new SslContextFactory.Client());
         this.insecureClient = new HttpClient(new SslContextFactory.Client(true));
         this.valueTransformationProvider = valueTransformationProvider;
+        // clear user agent, this needs to be set later in the thing configuration as additional header
+        this.secureClient.setUserAgentField(null);
+        this.insecureClient.setUserAgentField(null);
         try {
             this.secureClient.start();
             this.insecureClient.start();
         } catch (Exception e) {
             // catching exception is necessary due to the signature of HttpClient.start()
-            logger.warn("Failed to start insecure http client: {}", e.getMessage());
-            throw new IllegalStateException("Could not create insecure HttpClient");
+            logger.warn("Failed to start http client: {}", e.getMessage());
+            throw new IllegalStateException("Could not create HttpClient", e);
         }
         this.httpDynamicStateDescriptionProvider = httpDynamicStateDescriptionProvider;
     }

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpThingHandler.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpThingHandler.java
@@ -345,14 +345,7 @@ public class HttpThingHandler extends BaseThingHandler {
                 }
             }
 
-            config.headers.forEach(header -> {
-                String[] keyValuePair = header.split("=", 2);
-                if (keyValuePair.length == 2) {
-                    request.header(keyValuePair[0], keyValuePair[1]);
-                } else {
-                    logger.warn("Splitting header '{}' failed. No '=' was found. Ignoring", header);
-                }
-            });
+            config.getHeaders().forEach(request::header);
 
             if (logger.isTraceEnabled()) {
                 logger.trace("Sending to '{}': {}", uri, Util.requestToLogString(request));

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/config/HttpThingConfig.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/config/HttpThingConfig.java
@@ -60,13 +60,8 @@ public class HttpThingConfig {
     public Map<String, String> getHeaders() {
         Map<String, String> headersMap = new HashMap<>();
         // add user agent first, in case it is also defined in the headers, it'll be overwritten
-        if (!userAgent.isBlank()) {
-            // custom user agent
-            headersMap.put(HttpHeader.USER_AGENT.asString(), userAgent.trim());
-        } else {
-            // use default: Jetty/<version>
-            headersMap.put(HttpHeader.USER_AGENT.asString(), "Jetty/" + Jetty.VERSION);
-        }
+        headersMap.put(HttpHeader.USER_AGENT.asString(),
+                userAgent.isBlank() ? "Jetty/" + Jetty.VERSION : userAgent.trim());
         headers.forEach(header -> {
             String[] keyValuePair = header.split("=", 2);
             if (keyValuePair.length == 2) {

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/config/HttpThingConfig.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/config/HttpThingConfig.java
@@ -60,14 +60,13 @@ public class HttpThingConfig {
     public Map<String, String> getHeaders() {
         Map<String, String> headersMap = new HashMap<>();
         // add user agent first, in case it is also defined in the headers, it'll be overwritten
-        if (userAgent.isBlank()) {
+        if (!userAgent.isBlank()) {
             // custom user agent
             headersMap.put(HttpHeader.USER_AGENT.asString(), userAgent.trim());
         } else {
             // use default: Jetty/<version>
             headersMap.put(HttpHeader.USER_AGENT.asString(), "Jetty/" + Jetty.VERSION);
         }
-        headersMap.put(HttpHeader.USER_AGENT.asString(), userAgent);
         headers.forEach(header -> {
             String[] keyValuePair = header.split("=", 2);
             if (keyValuePair.length == 2) {

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/RateLimitedHttpClient.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/RateLimitedHttpClient.java
@@ -56,7 +56,7 @@ public class RateLimitedHttpClient {
      */
     public void shutdown() {
         stopProcessJob();
-        requestQueue.forEach(queueEntry -> queueEntry.future.completeExceptionally(new CancellationException()));
+        requestQueue.forEach(RequestQueueEntry::cancel);
     }
 
     /**
@@ -154,6 +154,13 @@ public class RateLimitedHttpClient {
                 request.content(new StringContentProvider(content));
             }
             future.complete(request);
+        }
+
+        /**
+         * cancel this request and complete the future with a {@link CancellationException}
+         */
+        public void cancel() {
+            future.completeExceptionally(new CancellationException());
         }
     }
 }

--- a/bundles/org.smarthomej.binding.http/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.http/src/main/resources/OH-INF/thing/thing-types.xml
@@ -113,6 +113,11 @@
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="userAgent" type="text">
+				<label>User Agent</label>
+				<description>Sets a custom user agent (default is "Jetty/version", e.g. "Jetty/9.4.20.v20190813").</description>
+				<advanced>true</advanced>
+			</parameter>
 		</config-description>
 	</thing-type>
 


### PR DESCRIPTION
Jetty always sets the User-Agent header. Adding an additional User-Agent header with the `headers` configuration results in two User-Agent headers. This PR adds a new configuration parameter that sllows to set the User-Agent to an arbitrary value. There is no check if the setting is valid.