### PR TITLE
[infrastructure] upgrade OHC to 3.0.2 to fix build from scratch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <maven.compiler.target>${oh.java.version}</maven.compiler.target>
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
-    <ohc.version>3.0.0</ohc.version>
+    <ohc.version>3.0.2</ohc.version>
     <bnd.version>5.3.0</bnd.version>
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.3.0</eea.version>


### PR DESCRIPTION
Because of the shutdown of Bintray/JCenter some dependencies were not available any longer. This resulted in build errors if the local maven repo did not contain those artifacts. This has been fixed in OHC 3.0.2.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>