### PR TITLE
[http] enable thing status changes on request result

### DIFF
--- a/bundles/org.smarthomej.binding.http/README.md
+++ b/bundles/org.smarthomej.binding.http/README.md
@@ -24,8 +24,9 @@ It can be extended with different channels.
 | `contentType`     | yes      |    -    | MIME content-type of the command requests. Only used for  `PUT` and `POST`. |
 | `encoding`        | yes      |    -    | Encoding to be used if no encoding is found in responses (advanced parameter). |  
 | `headers`         | yes      |    -    | Additional headers that are sent along with the request. Format is "header=value". Multiple values can be stored as `headers="key1=value1", "key2=value2", "key3=value3",`| 
-| `ignoreSSLErrors` | no       |  false  | If set to true ignores invalid SSL certificate errors. This is potentially dangerous.|
-| `userAgent`       | yes      |   yes   | Sets a custom user agent (default is "Jetty/version", e.g. "Jetty/9.4.20.v20190813"). |
+| `ignoreSSLErrors` | no       |  false  | If set to true, ignores invalid SSL certificate errors. This is potentially dangerous.|
+| `strictErrorHandling` | no   |  false  | If set to true, thing status is changed depending on last request result (failed = `OFFLINE`). Failed requests result in `UNDEF` for channel values. |
+| `userAgent`       | yes      |  (yes ) | Sets a custom user agent (default is "Jetty/version", e.g. "Jetty/9.4.20.v20190813"). |
 
 *Note:* Optional "no" means that you have to configure a value unless a default is provided, and you are ok with that setting.
 
@@ -42,6 +43,9 @@ Using escaped strings in URL parameters may lead to problems with the formatting
 
 ## Channels
 
+The thing has two channels of type `requestDateTime` which provide the timestamp of the last successful (`lastSuccess`) and last failed (`lastFailure`) request.
+
+Additionally, the thing can be extended with data channels.
 Each item type has its own channel-type.
 Depending on the channel-type, channels have different configuration options.
 All channel-types (except `image`) have `stateExtension`, `commandExtension`, `stateTransformation`, `commandTransformation` and `mode` parameters.

--- a/bundles/org.smarthomej.binding.http/pom.xml
+++ b/bundles/org.smarthomej.binding.http/pom.xml
@@ -14,12 +14,76 @@
 
   <name>SmartHome/J Add-ons :: Bundles :: HTTP Binding</name>
 
+  <properties>
+    <jetty.version>9.4.20.v20190813</jetty.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.smarthomej.addons.bundles</groupId>
       <artifactId>org.smarthomej.commons</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <!-- testing, we need to exclude and declare jetty bundles because the declared transitive dependency 9.2.28 is too old -->
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>2.27.2</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlets</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-proxy</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-webapp</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlets</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-proxy</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpBindingConstants.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpBindingConstants.java
@@ -15,6 +15,7 @@ package org.smarthomej.binding.http.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.type.ChannelTypeUID;
 
 /**
  * The {@link HttpBindingConstants} class defines common constants, which are
@@ -24,8 +25,12 @@ import org.openhab.core.thing.ThingTypeUID;
  */
 @NonNullByDefault
 public class HttpBindingConstants {
-
     private static final String BINDING_ID = "http";
 
     public static final ThingTypeUID THING_TYPE_URL = new ThingTypeUID(BINDING_ID, "url");
+
+    public static final ChannelTypeUID REQUEST_DATE_TIME_CHANNELTYPE_UID = new ChannelTypeUID(BINDING_ID,
+            "requestDateTime");
+    public static final String CHANNEL_LAST_SUCCESS = "lastSuccess";
+    public static final String CHANNEL_LAST_FAILURE = "lastFailure";
 }

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpStatusListener.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpStatusListener.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.http.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link HttpStatusListener} is an interface for reporting HTTP request states
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public interface HttpStatusListener {
+    /**
+     * report an error
+     *
+     * @param message optional error message
+     */
+    void onHttpError(@Nullable String message);
+
+    /**
+     * report a successful request
+     */
+    void onHttpSuccess();
+}

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/config/HttpThingConfig.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/config/HttpThingConfig.java
@@ -52,6 +52,7 @@ public class HttpThingConfig {
     public @Nullable String contentType = null;
 
     public boolean ignoreSSLErrors = false;
+    public boolean strictErrorHandling = false;
 
     // ArrayList is required as implementation because list may be modified later
     public ArrayList<String> headers = new ArrayList<>();

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/HttpResponseListener.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/HttpResponseListener.java
@@ -27,7 +27,6 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.smarthomej.binding.http.internal.HttpStatusListener;
 import org.smarthomej.commons.itemvalueconverter.ContentWrapper;
 
 /**

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/HttpStatusListener.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/HttpStatusListener.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.smarthomej.binding.http.internal;
+package org.smarthomej.binding.http.internal.http;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/RateLimitedHttpClient.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/RateLimitedHttpClient.java
@@ -25,10 +25,13 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Authentication;
 import org.eclipse.jetty.client.api.AuthenticationStore;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link RateLimitedHttpClient} is a wrapper for a Jetty HTTP client that limits the number of requests by delaying
@@ -39,10 +42,14 @@ import org.eclipse.jetty.http.HttpMethod;
 @NonNullByDefault
 public class RateLimitedHttpClient {
     private static final int MAX_QUEUE_SIZE = 1000; // maximum queue size
+    private final Logger logger = LoggerFactory.getLogger(RateLimitedHttpClient.class);
+
     private HttpClient httpClient;
     private int delay = 0; // in ms
     private final ScheduledExecutorService scheduler;
     private final LinkedBlockingQueue<RequestQueueEntry> requestQueue = new LinkedBlockingQueue<>(MAX_QUEUE_SIZE);
+    private final LinkedBlockingQueue<RequestQueueEntry> priorityRequestQueue = new LinkedBlockingQueue<>(
+            MAX_QUEUE_SIZE);
 
     private @Nullable ScheduledFuture<?> processJob;
 
@@ -61,7 +68,7 @@ public class RateLimitedHttpClient {
 
     /**
      * Set a new delay
-     * 
+     *
      * @param delay in ms between to requests
      */
     public void setDelay(int delay) {
@@ -78,7 +85,7 @@ public class RateLimitedHttpClient {
     /**
      * Set the HTTP client
      *
-     * @param httpClient secure or insecure Jetty http client
+     * @param httpClient secure or insecure {@link HttpClient}
      */
     public void setHttpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
@@ -90,29 +97,68 @@ public class RateLimitedHttpClient {
      * @param finalUrl the request URL
      * @param method http request method GET/PUT/POST
      * @param content the content (if method PUT/POST)
-     * @return a CompletableFuture that completes with the request
+     * @return a {@link CompletableFuture} that completes with the request
      */
-    public CompletableFuture<Request> newRequest(URI finalUrl, HttpMethod method, String content) {
+    public CompletableFuture<Request> newRequest(URI finalUrl, HttpMethod method, String content,
+            @Nullable String contentType) {
+        return queueRequest(finalUrl, method, content, contentType, requestQueue);
+    }
+
+    /**
+     * Create a new priority request (executed as next request) to the given URL respecting rate-limits
+     *
+     * @param finalUrl the request URL
+     * @param method http request method GET/PUT/POST
+     * @param content the content (if method PUT/POST)
+     * @return a {@link CompletableFuture} that completes with the request
+     */
+    public CompletableFuture<Request> newPriorityRequest(URI finalUrl, HttpMethod method, String content,
+            @Nullable String contentType) {
+        return queueRequest(finalUrl, method, content, contentType, priorityRequestQueue);
+    }
+
+    private CompletableFuture<Request> queueRequest(URI finalUrl, HttpMethod method, String content,
+            @Nullable String contentType, LinkedBlockingQueue<RequestQueueEntry> queue) {
         // if no delay is set, return a completed CompletableFuture
         CompletableFuture<Request> future = new CompletableFuture<>();
-        RequestQueueEntry queueEntry = new RequestQueueEntry(finalUrl, method, content, future);
+        RequestQueueEntry queueEntry = new RequestQueueEntry(finalUrl, method, content, contentType, future);
         if (delay == 0) {
             queueEntry.completeFuture(httpClient);
         } else {
-            if (!requestQueue.offer(queueEntry)) {
+            if (!queue.offer(queueEntry)) {
                 future.completeExceptionally(new RejectedExecutionException("Maximum queue size exceeded."));
             }
+
         }
         return future;
     }
 
     /**
-     * Get the AuthenticationStore from the wrapped client
+     * Get the {@link AuthenticationStore} from the wrapped {@link HttpClient}
      *
      * @return
      */
     public AuthenticationStore getAuthenticationStore() {
         return httpClient.getAuthenticationStore();
+    }
+
+    /**
+     * Remove authentication result from the wrapped {@link HttpClient} and force re-auth
+     *
+     * @param uri the {@link URI} associated with the authentication result
+     * @return true if a result was found and cleared, false if not authenticated at all
+     */
+    public boolean reAuth(URI uri) {
+        AuthenticationStore authStore = httpClient.getAuthenticationStore();
+        Authentication.Result authResult = authStore.findAuthenticationResult(uri);
+        if (authResult != null) {
+            authStore.removeAuthenticationResult(authResult);
+            logger.debug("Cleared authentication result for '{}', retrying immediately", uri);
+            return true;
+        } else {
+            logger.warn("Could not find authentication result for '{}', failing here", uri);
+            return false;
+        }
     }
 
     private void stopProcessJob() {
@@ -123,8 +169,15 @@ public class RateLimitedHttpClient {
         }
     }
 
+    /**
+     * Gets an request from either the priority queue or tge regular queue and creates the request
+     */
     private void processQueue() {
-        RequestQueueEntry queueEntry = requestQueue.poll();
+        RequestQueueEntry queueEntry = priorityRequestQueue.poll();
+        if (queueEntry == null) {
+            // no entry in priorityRequestQueue, try the regular queue
+            queueEntry = requestQueue.poll();
+        }
         if (queueEntry != null) {
             queueEntry.completeFuture(httpClient);
         }
@@ -134,12 +187,15 @@ public class RateLimitedHttpClient {
         private URI finalUrl;
         private HttpMethod method;
         private String content;
+        private @Nullable String contentType;
         private CompletableFuture<Request> future;
 
-        public RequestQueueEntry(URI finalUrl, HttpMethod method, String content, CompletableFuture<Request> future) {
+        public RequestQueueEntry(URI finalUrl, HttpMethod method, String content, @Nullable String contentType,
+                CompletableFuture<Request> future) {
             this.finalUrl = finalUrl;
             this.method = method;
             this.content = content;
+            this.contentType = contentType;
             this.future = future;
         }
 
@@ -151,7 +207,11 @@ public class RateLimitedHttpClient {
         public void completeFuture(HttpClient httpClient) {
             Request request = httpClient.newRequest(finalUrl).method(method);
             if (method != HttpMethod.GET && !content.isEmpty()) {
-                request.content(new StringContentProvider(content));
+                if (contentType == null) {
+                    request.content(new StringContentProvider(content));
+                } else {
+                    request.content(new StringContentProvider(content), contentType);
+                }
             }
             future.complete(request);
         }

--- a/bundles/org.smarthomej.binding.http/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.http/src/main/resources/OH-INF/thing/thing-types.xml
@@ -9,6 +9,19 @@
 		<label>HTTP URL Thing</label>
 		<description>Represents a base URL and all associated requests.</description>
 
+		<channels>
+			<channel typeId="requestDateTime" id="lastFailure">
+				<label>Last Failure</label>
+			</channel>
+			<channel typeId="requestDateTime" id="lastSuccess">
+				<label>Last Success</label>
+			</channel>
+		</channels>
+
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
+
 		<config-description>
 			<parameter name="baseURL" type="text" required="true">
 				<label>Base URL</label>
@@ -120,6 +133,12 @@
 			</parameter>
 		</config-description>
 	</thing-type>
+
+	<channel-type id="requestDateTime">
+		<item-type>DateTime</item-type>
+		<label>Dummy </label>
+		<state readOnly="true" pattern="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"/>
+	</channel-type>
 
 	<channel-type id="color">
 		<item-type>Color</item-type>

--- a/bundles/org.smarthomej.binding.http/src/main/resources/update/url.update
+++ b/bundles/org.smarthomej.binding.http/src/main/resources/update/url.update
@@ -1,0 +1,3 @@
+# add last success and last failure channels
+1;ADD_CHANNEL;lastSuccess,DateTime,http:requestDateTime,Last Success
+1;ADD_CHANNEL;lastFailure,DateTime,http:requestDateTime,Last Failure

--- a/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/AbstractWireMockTest.java
+++ b/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/AbstractWireMockTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.removeAllMappings;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.openhab.core.test.TestPortUtil;
+import org.openhab.core.test.java.JavaTest;
+import org.smarthomej.binding.http.internal.http.RateLimitedHttpClient;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+
+/**
+ * The {@link AbstractWireMockTest} implements tests for the {@link RateLimitedHttpClient}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public abstract class AbstractWireMockTest extends JavaTest {
+    protected int port = 0;
+    protected @NonNullByDefault({}) WireMockServer wireMockServer;
+    protected @NonNullByDefault({}) HttpClient httpClient;
+    protected ScheduledExecutorService scheduler = new ScheduledThreadPoolExecutor(4);
+
+    @BeforeAll
+    public void initAll() throws Exception {
+        port = TestPortUtil.findFreePort();
+
+        wireMockServer = new WireMockServer(options().port(port).extensions(new ResponseTemplateTransformer(false)));
+        wireMockServer.start();
+
+        httpClient = new HttpClient();
+        httpClient.start();
+
+        configureFor("localhost", port);
+    }
+
+    @AfterEach
+    public void cleanUpTest() {
+        removeAllMappings();
+    }
+
+    @AfterAll
+    public void cleanUpAll() throws Exception {
+        wireMockServer.shutdown();
+        scheduler.shutdown();
+        httpClient.stop();
+    }
+}

--- a/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/RateLimitedHttpClientTest.java
+++ b/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/RateLimitedHttpClientTest.java
@@ -17,10 +17,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.URI;
 import java.util.List;
@@ -84,9 +87,11 @@ public class RateLimitedHttpClientTest extends AbstractWireMockTest {
     public void testWithLimitAndPriority() {
         doLimitTest(500, List.of(false, false, true));
 
-        // we except to receive the responses of request 3 before request two
-        assertEquals(0, responses.get(0).seqNumber);
-        assertEquals(2, responses.get(1).seqNumber);
+        // we expect to receive the responses of request 3 before request two, exact order of 1 and 3 depends on timing,
+        // so accept both
+        assertThat(responses.get(0).seqNumber, anyOf(equalTo(0), equalTo(2)));
+        assertThat(responses.get(1).seqNumber, anyOf(equalTo(0), equalTo(2)));
+        assertNotEquals(responses.get(1).seqNumber, responses.get(0).seqNumber);
         assertEquals(1, responses.get(2).seqNumber);
 
         // we expect at least 2*500=1000ms delay between the first and last request, but less than 2*500+100=1100 ms

--- a/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/RateLimitedHttpClientTest.java
+++ b/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/RateLimitedHttpClientTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpMethod;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.smarthomej.binding.http.internal.http.RateLimitedHttpClient;
+
+/**
+ * The {@link RateLimitedHttpClientTest} implements tests for the {@link RateLimitedHttpClient}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RateLimitedHttpClientTest extends AbstractWireMockTest {
+    private static final String TEST_LOCATION = "/testlocation";
+    private static final String TEST_CONTENT = "TESTCONTENT";
+
+    private List<Response> responses = new CopyOnWriteArrayList<>();
+
+    @AfterEach
+    public void cleanUpTest() {
+        responses.clear();
+        super.cleanUpTest();
+    }
+
+    @Test
+    public void testWithoutLimit() {
+        doLimitTest(0, List.of(false, false));
+
+        // we except to receive the responses in the correct order
+        assertEquals(0, responses.get(0).seqNumber);
+        assertEquals(1, responses.get(1).seqNumber);
+
+        // we expect a short delay between both requests, but less than 100ms
+        long msBetween = responses.get(1).time - responses.get(0).time;
+        assertThat((int) msBetween, allOf(greaterThanOrEqualTo(0), lessThan(100)));
+    }
+
+    @Test
+    public void testWithLimit() {
+        doLimitTest(500, List.of(false, false));
+        // we except to receive the responses in the correct order
+        assertEquals(0, responses.get(0).seqNumber);
+        assertEquals(1, responses.get(1).seqNumber);
+
+        // we expect at least 500ms delay between both requests, but less than 500+100=600ms
+        long msBetween = responses.get(1).time - responses.get(0).time;
+        assertThat((int) msBetween, allOf(greaterThanOrEqualTo(500), lessThan(600)));
+    }
+
+    @Test
+    public void testWithLimitAndPriority() {
+        doLimitTest(500, List.of(false, false, true));
+
+        // we except to receive the responses of request 3 before request two
+        assertEquals(0, responses.get(0).seqNumber);
+        assertEquals(2, responses.get(1).seqNumber);
+        assertEquals(1, responses.get(2).seqNumber);
+
+        // we expect at least 2*500=1000ms delay between the first and last request, but less than 2*500+100=1100 ms
+        long msBetween = responses.get(2).time - responses.get(0).time;
+        assertThat((int) msBetween, allOf(greaterThanOrEqualTo(1000), lessThan(1100)));
+    }
+
+    private List<Response> doLimitTest(int setDelay, List<Boolean> config) {
+        stubFor(get(urlEqualTo(TEST_LOCATION)).willReturn(aResponse().withBody(TEST_CONTENT)));
+
+        RateLimitedHttpClient rateLimitedHttpClient = new RateLimitedHttpClient(httpClient, scheduler);
+        rateLimitedHttpClient.setDelay(setDelay);
+
+        URI url = URI.create("http://localhost:" + port + TEST_LOCATION);
+        int seqNumber = 0;
+
+        for (boolean priority : config) {
+            int nextSeqNumber = seqNumber++;
+            CompletableFuture<Request> requestFuture;
+
+            if (priority) {
+                requestFuture = rateLimitedHttpClient.newPriorityRequest(url, HttpMethod.GET, "", null);
+            } else {
+                requestFuture = rateLimitedHttpClient.newRequest(url, HttpMethod.GET, "", null);
+            }
+
+            requestFuture.thenAccept(request -> {
+                try {
+                    responses.add(new Response(nextSeqNumber, request.send()));
+                } catch (Exception e) {
+                }
+            });
+        }
+
+        // wait until we got all results
+        waitForAssert(() -> assertEquals(config.size(), responses.size()));
+        rateLimitedHttpClient.shutdown();
+
+        return responses;
+    }
+
+    private static class Response {
+        public final int seqNumber;
+        public final long time = System.currentTimeMillis();
+        public final String content;
+
+        public Response(int seqNumber, ContentResponse contentResponse) {
+            this.seqNumber = seqNumber;
+            this.content = contentResponse.getContentAsString();
+        }
+    }
+}

--- a/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/RefreshingUrlCacheTest.java
+++ b/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/RefreshingUrlCacheTest.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.util.Jetty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.smarthomej.binding.http.internal.config.HttpThingConfig;
+import org.smarthomej.binding.http.internal.http.HttpStatusListener;
+import org.smarthomej.binding.http.internal.http.RateLimitedHttpClient;
+import org.smarthomej.binding.http.internal.http.RefreshingUrlCache;
+import org.smarthomej.commons.itemvalueconverter.ContentWrapper;
+
+/**
+ * The {@link RefreshingUrlCacheTest} implements tests for the {@link RefreshingUrlCache}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RefreshingUrlCacheTest extends AbstractWireMockTest {
+    private static final String TEST_LOCATION = "/testlocation";
+    private static final String TEST_CONTENT = "TESTCONTENT";
+
+    private @NonNullByDefault({}) RateLimitedHttpClient rateLimitedHttpClient;
+    private @NonNullByDefault({}) HttpThingConfig thingConfig;
+    private @NonNullByDefault({}) String url;
+    private @NonNullByDefault({}) HttpStatusListener statusListener;
+
+    private List<@Nullable ContentWrapper> contentWrappers = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    public void initTest() {
+        // this is usually done inside the HttpHandlerFactory when creating the clients
+        httpClient.setUserAgentField(null);
+
+        // create a RateLimitedHttpClient
+        rateLimitedHttpClient = new RateLimitedHttpClient(httpClient, scheduler);
+        rateLimitedHttpClient.setDelay(0);
+        statusListener = mock(HttpStatusListener.class);
+
+        // initialize thing config with some default values
+        thingConfig = new HttpThingConfig();
+        thingConfig.baseURL = "http://localhost:" + port;
+        thingConfig.timeout = 500;
+        thingConfig.refresh = 1;
+
+        url = thingConfig.baseURL + TEST_LOCATION;
+    }
+
+    @AfterEach
+    public void cleanUpTest() {
+        rateLimitedHttpClient.shutdown();
+        contentWrappers.clear();
+        super.cleanUpTest();
+    }
+
+    @Test
+    public void testUpdateOnSuccessfulRequest() {
+        stubFor(get(urlEqualTo(TEST_LOCATION)).willReturn(aResponse().withBody(TEST_CONTENT)));
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // wait until we got at least four results or timeout (after 10s)
+        waitForAssert(() -> assertEquals(4, contentWrappers.size()));
+        urlCache.stop();
+
+        // verify we did not have errors and the number of responses matches the number of success calls
+        verify(statusListener, never()).onHttpError(any());
+        verify(statusListener, times(contentWrappers.size())).onHttpSuccess();
+
+        // assert all content equals the correct value
+        assertTrue(contentWrappers.stream().map(Objects::requireNonNull).map(ContentWrapper::getAsString)
+                .allMatch(TEST_CONTENT::equals));
+    }
+
+    @Test
+    public void testNoUpdateOn404ErrorInNormalMode() {
+        stubFor(get(urlEqualTo(TEST_LOCATION)).willReturn(aResponse().withStatus(404)));
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // verify we get at least two error reports in 3s
+        verify(statusListener, timeout(3000).atLeast(2)).onHttpError(any());
+        verify(statusListener, never()).onHttpSuccess();
+        urlCache.stop();
+
+        // assert all content equals the correct value
+        assertEquals(true, contentWrappers.isEmpty());
+    }
+
+    @Test
+    public void testNullUpdateOn404ErrorInStrictMode() {
+        stubFor(get(urlEqualTo(TEST_LOCATION)).willReturn(aResponse().withStatus(404)));
+        thingConfig.strictErrorHandling = true;
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // verify we get at least two error reports in 3s
+        verify(statusListener, timeout(3000).atLeast(2)).onHttpError(any());
+        verify(statusListener, never()).onHttpSuccess();
+        urlCache.stop();
+
+        int totalErrorCalls = mockingDetails(statusListener).getInvocations().size();
+
+        // assert we have the same number of consumer calls as error calls and all are null
+        assertEquals(totalErrorCalls, contentWrappers.size());
+        assertEquals(true, contentWrappers.stream().allMatch(Objects::isNull));
+    }
+
+    @Test
+    public void testNoUpdateOnRequestTimedOutInNormalMode() {
+        stubFor(get(urlEqualTo(TEST_LOCATION)).willReturn(aResponse().withFixedDelay(1000).withStatus(200)));
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // verify we get at least two error reports in 3s
+        verify(statusListener, timeout(3000).atLeast(2)).onHttpError(any());
+        verify(statusListener, never()).onHttpSuccess();
+        urlCache.stop();
+
+        // assert all content equals the correct value
+        assertEquals(true, contentWrappers.isEmpty());
+    }
+
+    @Test
+    public void testNullUpdateOnRequestTimedOutInStrictMode() {
+        stubFor(get(urlEqualTo(TEST_LOCATION)).willReturn(aResponse().withFixedDelay(1000).withStatus(200)));
+        thingConfig.strictErrorHandling = true;
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // verify we get at least two error reports in 3s
+        verify(statusListener, timeout(3000).atLeast(2)).onHttpError(any());
+        verify(statusListener, never()).onHttpSuccess();
+        urlCache.stop();
+
+        int totalErrorCalls = mockingDetails(statusListener).getInvocations().size();
+
+        // assert we have the same number of consumer calls as error calls and all are null
+        assertEquals(totalErrorCalls, contentWrappers.size());
+        assertEquals(true, contentWrappers.stream().allMatch(Objects::isNull));
+    }
+
+    @Test
+    public void testAdditionalHeaderIsSentWithRequest() {
+        String testHeaderKey = "X-SMARTHOME";
+        String testHeaderValue = "TESTVALUE";
+
+        stubFor(get(urlEqualTo(TEST_LOCATION)).willReturn(aResponse()
+                .withBody("{{request.headers." + testHeaderKey + "}}").withTransformers("response-template")));
+        thingConfig.headers = new ArrayList<>(List.of(testHeaderKey + "=" + testHeaderValue));
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // we need only one answer
+        waitForAssert(() -> assertFalse(contentWrappers.isEmpty()));
+        urlCache.stop();
+
+        String returnedHeaderValue = Objects.requireNonNull(contentWrappers.get(0)).getAsString();
+        assertEquals(testHeaderValue, returnedHeaderValue);
+    }
+
+    @Test
+    public void testUserAgentIsJettyWhenNotConfigured() {
+        stubFor(get(urlEqualTo(TEST_LOCATION)).willReturn(
+                aResponse().withBody("{{request.headers.User-Agent}}").withTransformers("response-template")));
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // we need only one answer
+        waitForAssert(() -> assertFalse(contentWrappers.isEmpty()));
+        urlCache.stop();
+
+        String returnedHeaderValue = Objects.requireNonNull(contentWrappers.get(0)).getAsString();
+        assertEquals("Jetty/" + Jetty.VERSION, returnedHeaderValue);
+    }
+
+    @Test
+    public void testContentSentAlongWithPost() {
+        stubFor(post(urlEqualTo(TEST_LOCATION))
+                .willReturn(aResponse().withBody("{{request.body}}").withTransformers("response-template")));
+        thingConfig.stateMethod = HttpMethod.POST;
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // we need only one answer
+        waitForAssert(() -> assertFalse(contentWrappers.isEmpty()));
+        urlCache.stop();
+
+        String returnedBody = Objects.requireNonNull(contentWrappers.get(0)).getAsString();
+        assertEquals(TEST_CONTENT, returnedBody);
+    }
+
+    @Test
+    public void testDateIsFormattedInURL() {
+        stubFor(get(urlPathEqualTo(TEST_LOCATION))
+                .willReturn(aResponse().withBody("{{request.query.date}}").withTransformers("response-template")));
+        url += "?date=%1$tY-%1$tm-%1$td";
+
+        RefreshingUrlCache urlCache = getUrlCache(TEST_CONTENT);
+
+        // we need only one answer
+        waitForAssert(() -> assertFalse(contentWrappers.isEmpty()));
+        urlCache.stop();
+
+        String returnedQueryValue = Objects.requireNonNull(contentWrappers.get(0)).getAsString();
+        assertTrue(returnedQueryValue.matches("\\d{4}-\\d{2}-\\d{2}"));
+    }
+
+    /**
+     * helper method to create a {@link RefreshingUrlCache} and add a test listener
+     *
+     * @param content HTTP content
+     * @return the cache object
+     */
+    private RefreshingUrlCache getUrlCache(String content) {
+        RefreshingUrlCache urlCache = new RefreshingUrlCache(scheduler, rateLimitedHttpClient, url, thingConfig,
+                content, statusListener);
+        urlCache.addConsumer(contentWrappers::add);
+
+        return urlCache;
+    }
+}


### PR DESCRIPTION
This enables the thing status (which was always "ONLINE") to be updated depending on the result of the last request. Also enables rate limits for sending commands (with priority over state requests).

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>