### PR TITLE
fix build

### DIFF
--- a/bom/openhab-core-index/pom.xml
+++ b/bom/openhab-core-index/pom.xml
@@ -22,6 +22,14 @@
       <type>pom</type>
       <scope>compile</scope>
       <optional>true</optional>
+      <exclusions>
+        <!-- This is needed because the jamod artifact defined in OH core 3.0.x is no longer available -->
+        <!-- Since OH 3.1.x depends on another version this should not be ported to 3.2.x -->
+        <exclusion>
+          <groupId>net.wimpi</groupId>
+          <artifactId>jamod</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -72,6 +72,12 @@
           <groupId>commons-net</groupId>
           <artifactId>commons-net</artifactId>
         </exclusion>
+        <!-- This is needed because the jamod artifact defined in OH core 3.0.x is no longer available -->
+        <!-- Since OH 3.1.x depends on another version this should not be ported to 3.2.x -->
+        <exclusion>
+          <groupId>net.wimpi</groupId>
+          <artifactId>jamod</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
This fixes the broken build-from-scratch by excluding the missiing `net.wimpi:jamod:1.2.4.OH` artifact. This is safe since none of our addons uses that dependency. Since we depend on the openHAB core BOM our build breaks, though. This is only necessary for the 3.1.x branch since the 3.2.x branch depends on openHAB core 3.1 which does not have that dependency.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>