### PR TITLE
[infrastructure] adapt to new UoM Library

### DIFF
--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/itemvalueconverter/converter/NumberItemConverter.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/itemvalueconverter/converter/NumberItemConverter.java
@@ -63,7 +63,7 @@ public class NumberItemConverter extends AbstractTransformingItemConverter {
                         newState = new QuantityType<>(trimmedValue);
                     }
                 }
-            } catch (IllegalArgumentException e) {
+            } catch (RuntimeException e) {
                 // finally failed
             }
         }

--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/itemvalueconverter/converter/NumberItemConverter.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/itemvalueconverter/converter/NumberItemConverter.java
@@ -16,6 +16,8 @@ package org.smarthomej.commons.itemvalueconverter.converter;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import javax.measure.format.MeasurementParseException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.DecimalType;
@@ -63,7 +65,7 @@ public class NumberItemConverter extends AbstractTransformingItemConverter {
                         newState = new QuantityType<>(trimmedValue);
                     }
                 }
-            } catch (RuntimeException e) {
+            } catch (IllegalArgumentException | MeasurementParseException e) {
                 // finally failed
             }
         }

--- a/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/itemvalueconverter/converter/ConverterTest.java
+++ b/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/itemvalueconverter/converter/ConverterTest.java
@@ -98,7 +98,6 @@ public class ConverterTest {
         Assertions.assertEquals(Optional.of(new QuantityType<>(500, Units.WATT)), converter.toState("500"));
 
         // no valid value
-        Assertions.assertEquals(Optional.of(UnDefType.UNDEF), converter.toState("100°C"));
         Assertions.assertEquals(Optional.of(UnDefType.UNDEF), converter.toState("foo"));
         Assertions.assertEquals(Optional.of(UnDefType.UNDEF), converter.toState(""));
     }


### PR DESCRIPTION
After the upgrade to the new UoM library in core the tests fail. This is because `100°C` (i.e. without space) is now a valid value. Another issue is that instead on an `IllegalArgumentException`  now a `MeasurementParseException` is thrown. 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>