### PR TITLE
Initial contribution of Math Transformation Service

### DIFF
--- a/bundles/org.smarthomej.transform.math/NOTICE
+++ b/bundles/org.smarthomej.transform.math/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the SmartHome/J project.
+
+* Project home: https://www.smarthomej.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/smarthomej/addons

--- a/bundles/org.smarthomej.transform.math/README.md
+++ b/bundles/org.smarthomej.transform.math/README.md
@@ -1,0 +1,19 @@
+# Math Transformation
+
+Transforms the input by applying simple math on it.
+
+## Full Example
+
+Example Items:
+
+```
+Number multiply "Value multiplied by [MULTIPLY(1000):%s]" { channel="xxx" }
+Number add "Value added [ADD(5.1):%s]" { channel="xxx" }
+```
+
+Example in Rules:
+
+```
+transform("MULTIPLY", "1000")
+transform("ADD", "5.1")
+```

--- a/bundles/org.smarthomej.transform.math/pom.xml
+++ b/bundles/org.smarthomej.transform.math/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.smarthomej.addons.bundles</groupId>
+    <artifactId>org.smarthomej.addons.reactor.bundles</artifactId>
+    <version>3.1.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.smarthomej.transform.math</artifactId>
+
+  <name>SmartHome/J Add-ons :: Bundles :: Transformation Service :: Math</name>
+
+</project>

--- a/bundles/org.smarthomej.transform.math/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.transform.math/src/main/feature/feature.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="org.smarthomej.transform.math-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features
+	</repository>
+
+	<feature name="smarthomej-transformation-math" description="Math Transformation" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<bundle start-level="75">mvn:org.smarthomej.addons.bundles/org.smarthomej.transform.math/${project.version}
+		</bundle>
+	</feature>
+</features>

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/AbstractMathTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/AbstractMathTransformationService.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.math.internal;
+
+import java.math.BigDecimal;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.transform.TransformationException;
+import org.openhab.core.transform.TransformationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract class for {@link TransformationService}s which applies simple math on the input.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+abstract class AbstractMathTransformationService implements TransformationService {
+    private final Logger logger = LoggerFactory.getLogger(AbstractMathTransformationService.class);
+
+    private static final Pattern NUMBER_PATTERN = Pattern.compile(".*?(-?((0)|([1-9][0-9]*))(\\.[0-9]*)?).*?");
+
+    @Override
+    public @Nullable String transform(String valueString, String sourceString) throws TransformationException {
+        BigDecimal source;
+        String extractedNumericString = extractNumericString(sourceString);
+        try {
+            source = new BigDecimal(extractedNumericString);
+        } catch (NumberFormatException e) {
+            logger.warn("Input value '{}' could not converted to a valid number", extractedNumericString);
+            throw new TransformationException("Math Transformation can only be used with numeric inputs");
+        }
+        BigDecimal value;
+        try {
+            value = new BigDecimal(extractNumericString(valueString));
+        } catch (NumberFormatException e) {
+            logger.warn("Input value '{}' could not converted to a valid number", extractNumericString(valueString));
+            throw new TransformationException("Math Transformation can only be used with numeric inputs");
+        }
+
+        String result = performCalculation(source, value).toString();
+        return sourceString.replace(extractedNumericString, result);
+    }
+
+    private String extractNumericString(String sourceString) throws TransformationException {
+        Matcher matcher = NUMBER_PATTERN.matcher(sourceString);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        } else {
+            throw new TransformationException("Math Transformation can only be used with numeric inputs");
+        }
+    }
+
+    abstract BigDecimal performCalculation(BigDecimal source, BigDecimal value);
+}

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/AddTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/AddTransformationService.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.math.internal;
+
+import java.math.BigDecimal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.transform.TransformationService;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This {@link TransformationService} adds the given value to the input.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { TransformationService.class }, property = { "openhab.transform=ADD" })
+public class AddTransformationService extends AbstractMathTransformationService {
+
+    @Override
+    BigDecimal performCalculation(BigDecimal source, BigDecimal value) {
+        return source.add(value);
+    }
+}

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/MultiplyTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/MultiplyTransformationService.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.math.internal;
+
+import java.math.BigDecimal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.transform.TransformationService;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This {@link TransformationService} multiplies the input by a given value.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { TransformationService.class }, property = { "openhab.transform=MULTIPLY" })
+public class MultiplyTransformationService extends AbstractMathTransformationService {
+
+    @Override
+    BigDecimal performCalculation(BigDecimal source, BigDecimal value) {
+        return source.multiply(value);
+    }
+}

--- a/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/AddTransformationServiceTest.java
+++ b/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/AddTransformationServiceTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.math.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.transform.TransformationException;
+import org.openhab.core.transform.TransformationService;
+
+/**
+ * Unit test for {@link AddTransformationService}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+class AddTransformationServiceTest {
+    private final TransformationService subject = new AddTransformationService();
+
+    @Test
+    public void testTransform() throws TransformationException {
+        String result = subject.transform("20", "100");
+
+        assertEquals("120", result);
+    }
+
+    @Test
+    public void testTransformInsideString() throws TransformationException {
+        String result = subject.transform("20", "100 watt");
+
+        assertEquals("120 watt", result);
+    }
+
+    public void testTransformInvalidSource() {
+        assertThrows(TransformationException.class, () -> subject.transform("20", "*"));
+    }
+
+    public void testTransformInvalidFunction() {
+        assertThrows(TransformationException.class, () -> subject.transform("*", "90"));
+    }
+}

--- a/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/MultiplyTransformationServiceTest.java
+++ b/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/MultiplyTransformationServiceTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.math.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.transform.TransformationException;
+import org.openhab.core.transform.TransformationService;
+
+/**
+ * Unit test for {@link MultiplyTransformationService}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+class MultiplyTransformationServiceTest {
+    private final TransformationService subject = new MultiplyTransformationService();
+
+    @Test
+    public void testTransform() throws TransformationException {
+        String result = subject.transform("20", "100");
+
+        assertEquals("2000", result);
+    }
+
+    @Test
+    public void testTransformInsideString() throws TransformationException {
+        String result = subject.transform("-20", "-0.5 watt");
+
+        assertEquals("10.0 watt", result);
+    }
+
+    public void testTransformInvalidSource() {
+        assertThrows(TransformationException.class, () -> subject.transform("20", "*"));
+    }
+
+    public void testTransformInvalidFunction() {
+        assertThrows(TransformationException.class, () -> subject.transform("*", "90"));
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -39,6 +39,7 @@
     <module>org.smarthomej.persistence.influxdb</module>
     <!-- transformations -->
     <module>org.smarthomej.transform.format</module>
+    <module>org.smarthomej.transform.math</module>
     <!-- manager -->
     <module>org.smarthomej.io.repomanager</module>
   </modules>


### PR DESCRIPTION
- Initial contribution of Math Transformation Service

The `ADD` transformation was deprecated for me when the Offset Profile has been introduced. But with the new Chain Profile it pops up in attention again.
I am using the `MULTIPLY` transformation to calculate energy consumption costs or carbon footprint.

I guess we can add related Profiles later.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>