### PR TITLE
fix spotless issues

### DIFF
--- a/bom/smarthomej-addons/pom.xml
+++ b/bom/smarthomej-addons/pom.xml
@@ -103,6 +103,11 @@
     </dependency>
     <dependency>
       <groupId>org.smarthomej.addons.bundles</groupId>
+      <artifactId>org.smarthomej.transform.math</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.smarthomej.addons.bundles</groupId>
       <artifactId>org.smarthomej.io.repomanager</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpThingHandler.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/HttpThingHandler.java
@@ -120,8 +120,9 @@ public class HttpThingHandler extends UpdatingBaseThingHandler implements HttpSt
                 if (refreshingUrlCache != null) {
                     try {
                         refreshingUrlCache.get().ifPresentOrElse(itemValueConverter::process, () -> {
-                            if (config.strictErrorHandling)
+                            if (config.strictErrorHandling) {
                                 itemValueConverter.process(null);
+                            }
                         });
                     } catch (IllegalArgumentException | IllegalStateException e) {
                         logger.warn("Failed processing REFRESH command for channel {}: {}", channelUID, e.getMessage());

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapper.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapper.java
@@ -15,8 +15,6 @@ package org.smarthomej.binding.knx.internal.dpt;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -749,28 +747,6 @@ public class KNXCoreTypeMapper implements KNXTypeMapper {
                         case 8:
                             return translator3BitControlled.getControlBit() ? UpDownType.DOWN : UpDownType.UP;
                     }
-                case 14:
-                    /*
-                     * FIXME: Workaround for a bug in Calimero / Openhab DPTXlator4ByteFloat.makeString(): is using a
-                     * locale when
-                     * translating a Float to String. It could happen the a ',' is used as separator, such as
-                     * 3,14159E20.
-                     * Openhab's DecimalType expects this to be in US format and expects '.': 3.14159E20.
-                     * There is no issue with DPTXlator2ByteFloat since calimero is using a non-localized translation
-                     * there.
-                     */
-                    DPTXlator4ByteFloat translator4ByteFloat = (DPTXlator4ByteFloat) translator;
-                    Float f = translator4ByteFloat.getValueFloat();
-                    if (Math.abs(f) < 100000) {
-                        value = String.valueOf(f);
-                    } else {
-                        NumberFormat dcf = NumberFormat.getInstance(Locale.US);
-                        if (dcf instanceof DecimalFormat) {
-                            ((DecimalFormat) dcf).applyPattern("0.#####E0");
-                        }
-                        value = dcf.format(f);
-                    }
-                    break;
                 case 18:
                     DPTXlatorSceneControl translatorSceneControl = (DPTXlatorSceneControl) translator;
                     int decimalValue = translatorSceneControl.getSceneNumber();

--- a/bundles/org.smarthomej.binding.notificationsforfiretv/src/main/java/org/smarthomej/binding/notificationsforfiretv/internal/NotificationsForFireTVHandler.java
+++ b/bundles/org.smarthomej.binding.notificationsforfiretv/src/main/java/org/smarthomej/binding/notificationsforfiretv/internal/NotificationsForFireTVHandler.java
@@ -42,8 +42,6 @@ import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.types.Command;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link NotificationsForFireTVHandler} is responsible for handling commands, which are
@@ -53,9 +51,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class NotificationsForFireTVHandler extends BaseThingHandler {
-
-    private final Logger logger = LoggerFactory.getLogger(NotificationsForFireTVHandler.class);
-
     private NotificationsForFireTVConfiguration config = new NotificationsForFireTVConfiguration();
 
     public NotificationsForFireTVHandler(Thing thing) {

--- a/bundles/org.smarthomej.binding.onewire/src/main/java/org/smarthomej/binding/onewire/internal/device/DS2438.java
+++ b/bundles/org.smarthomej.binding.onewire/src/main/java/org/smarthomej/binding/onewire/internal/device/DS2438.java
@@ -92,7 +92,7 @@ public class DS2438 extends AbstractOwDevice {
     public void refresh(OwserverBridgeHandler bridgeHandler, Boolean forcedRefresh) throws OwException {
         if (isConfigured) {
             logger.trace("refresh of sensor {} started", sensorId);
-            double Vcc = 5.0;
+            double vcc = 5.0;
 
             if (enabledChannels.contains(CHANNEL_TEMPERATURE) || enabledChannels.contains(CHANNEL_HUMIDITY)
                     || enabledChannels.contains(CHANNEL_ABSOLUTE_HUMIDITY)
@@ -160,8 +160,8 @@ public class DS2438 extends AbstractOwDevice {
             }
 
             if (enabledChannels.contains(CHANNEL_SUPPLYVOLTAGE)) {
-                Vcc = ((DecimalType) bridgeHandler.readDecimalType(sensorId, supplyVoltageParameter)).doubleValue();
-                State supplyVoltage = new QuantityType<>(Vcc, Units.VOLT);
+                vcc = ((DecimalType) bridgeHandler.readDecimalType(sensorId, supplyVoltageParameter)).doubleValue();
+                State supplyVoltage = new QuantityType<>(vcc, Units.VOLT);
                 callback.postUpdate(CHANNEL_SUPPLYVOLTAGE, supplyVoltage);
             }
 
@@ -193,7 +193,7 @@ public class DS2438 extends AbstractOwDevice {
                             // workaround bug in DS2438
                             light = new QuantityType<>(0, Units.LUX);
                         } else {
-                            light = new QuantityType<>(Math.pow(10, (65 / 7.5) - (47 / 7.5) * (Vcc / measured)),
+                            light = new QuantityType<>(Math.pow(10, (65 / 7.5) - (47 / 7.5) * (vcc / measured)),
                                     Units.LUX);
                         }
                         callback.postUpdate(CHANNEL_LIGHT, light);

--- a/bundles/org.smarthomej.binding.telenot/README.md
+++ b/bundles/org.smarthomej.binding.telenot/README.md
@@ -11,6 +11,7 @@ Connect this module to the GMS-Port (Serial).
 You have to enable the GMS-Protocol in the CompasX Software.
 
 ## Note
+
 The Building management protocol is a two-way street. 
 Not only can you get info from your alarm system, that same protocol can be used to send commands to the alarm system too! 
 A black hatter might use this to tell your system to disarm itself using the cimmunications infrastructure that we have conveniently built for him. 


### PR DESCRIPTION
- add {} for if (http)
- remove unnecessary workaround in knx (already fixed in calimero 2.4)
- remove unused logger (notificationsforfiretv)
- fix local variable naming (onewire)
- fix markdown in documentation (telenot)

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>