### PR TITLE
[transform.math] add divide

### DIFF
--- a/bundles/org.smarthomej.transform.math/README.md
+++ b/bundles/org.smarthomej.transform.math/README.md
@@ -9,6 +9,7 @@ Example Items:
 ```
 Number multiply "Value multiplied by [MULTIPLY(1000):%s]" { channel="xxx" }
 Number add "Value added [ADD(5.1):%s]" { channel="xxx" }
+Number secondsToMinutes "Time [DIVIDE(60):%s]" { channel="xxx" }
 ```
 
 Example in Rules:
@@ -16,4 +17,5 @@ Example in Rules:
 ```
 transform("MULTIPLY", "1000")
 transform("ADD", "5.1")
+transform("DIVIDE", "60")
 ```

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/AbstractMathTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/AbstractMathTransformationService.java
@@ -65,5 +65,5 @@ abstract class AbstractMathTransformationService implements TransformationServic
         }
     }
 
-    abstract BigDecimal performCalculation(BigDecimal source, BigDecimal value);
+    abstract BigDecimal performCalculation(BigDecimal source, BigDecimal value) throws TransformationException;
 }

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/AbstractMathTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/AbstractMathTransformationService.java
@@ -51,9 +51,12 @@ abstract class AbstractMathTransformationService implements TransformationServic
             logger.warn("Input value '{}' could not converted to a valid number", extractNumericString(valueString));
             throw new TransformationException("Math Transformation can only be used with numeric inputs");
         }
-
-        String result = performCalculation(source, value).toString();
-        return sourceString.replace(extractedNumericString, result);
+        try {
+            String result = performCalculation(source, value).toString();
+            return sourceString.replace(extractedNumericString, result);
+        } catch (ArithmeticException e) {
+            throw new TransformationException("ArithmeticException: " + e.getMessage());
+        }
     }
 
     private String extractNumericString(String sourceString) throws TransformationException {
@@ -65,5 +68,5 @@ abstract class AbstractMathTransformationService implements TransformationServic
         }
     }
 
-    abstract BigDecimal performCalculation(BigDecimal source, BigDecimal value) throws TransformationException;
+    abstract BigDecimal performCalculation(BigDecimal source, BigDecimal value);
 }

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/DivideTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/DivideTransformationService.java
@@ -15,6 +15,7 @@ package org.smarthomej.binding.math.internal;
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationService;
 import org.osgi.service.component.annotations.Component;
 
@@ -28,7 +29,11 @@ import org.osgi.service.component.annotations.Component;
 public class DivideTransformationService extends AbstractMathTransformationService {
 
     @Override
-    BigDecimal performCalculation(BigDecimal source, BigDecimal value) {
-        return source.divide(value);
+    BigDecimal performCalculation(BigDecimal source, BigDecimal value) throws TransformationException {
+        try {
+            return source.divide(value);
+        } catch (ArithmeticException e) {
+            throw new TransformationException("ArithmeticException: " + e.getMessage());
+        }
     }
 }

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/DivideTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/DivideTransformationService.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.math.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.transform.TransformationService;
+import org.osgi.service.component.annotations.Component;
+
+import java.math.BigDecimal;
+
+/**
+ * This {@link TransformationService} divides the input by a given value.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { TransformationService.class }, property = { "openhab.transform=DIVIDE" })
+public class DivideTransformationService extends AbstractMathTransformationService {
+
+    @Override
+    BigDecimal performCalculation(BigDecimal source, BigDecimal value) {
+        return source.divide(value);
+    }
+}

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/DivideTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/DivideTransformationService.java
@@ -15,7 +15,6 @@ package org.smarthomej.binding.math.internal;
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationService;
 import org.osgi.service.component.annotations.Component;
 
@@ -29,11 +28,7 @@ import org.osgi.service.component.annotations.Component;
 public class DivideTransformationService extends AbstractMathTransformationService {
 
     @Override
-    BigDecimal performCalculation(BigDecimal source, BigDecimal value) throws TransformationException {
-        try {
-            return source.divide(value);
-        } catch (ArithmeticException e) {
-            throw new TransformationException("ArithmeticException: " + e.getMessage());
-        }
+    BigDecimal performCalculation(BigDecimal source, BigDecimal value) {
+        return source.divide(value);
     }
 }

--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/DivideTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/binding/math/internal/DivideTransformationService.java
@@ -12,11 +12,11 @@
  */
 package org.smarthomej.binding.math.internal;
 
+import java.math.BigDecimal;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.transform.TransformationService;
 import org.osgi.service.component.annotations.Component;
-
-import java.math.BigDecimal;
 
 /**
  * This {@link TransformationService} divides the input by a given value.

--- a/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/AddTransformationServiceTest.java
+++ b/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/AddTransformationServiceTest.java
@@ -42,6 +42,7 @@ class AddTransformationServiceTest {
         assertEquals("120 watt", result);
     }
 
+    @Test
     public void testTransformInvalidSource() {
         assertThrows(TransformationException.class, () -> subject.transform("20", "*"));
     }

--- a/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/DivideTransformationServiceTest.java
+++ b/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/DivideTransformationServiceTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.math.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.transform.TransformationException;
+import org.openhab.core.transform.TransformationService;
+
+/**
+ * Unit test for {@link DivideTransformationService}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ * @author Jan N. Klug - adapted to DivideTransformation
+ */
+@NonNullByDefault
+class DivideTransformationServiceTest {
+    private final TransformationService subject = new DivideTransformationService();
+
+    @Test
+    public void testTransform() throws TransformationException {
+        String result = subject.transform("-20", "-2000");
+
+        assertEquals("100", result);
+    }
+
+    @Test
+    public void testTransformInsideString() throws TransformationException {
+        String result = subject.transform("60", "90 watts");
+
+        assertEquals("1.5 watts", result);
+    }
+
+    public void testTransformInvalidSource() {
+        assertThrows(TransformationException.class, () -> subject.transform("20", "*"));
+    }
+
+    public void testTransformInvalidFunction() {
+        assertThrows(TransformationException.class, () -> subject.transform("*", "90"));
+    }
+}

--- a/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/DivideTransformationServiceTest.java
+++ b/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/DivideTransformationServiceTest.java
@@ -44,11 +44,18 @@ class DivideTransformationServiceTest {
         assertEquals("1.5 watts", result);
     }
 
+    @Test
     public void testTransformInvalidSource() {
         assertThrows(TransformationException.class, () -> subject.transform("20", "*"));
     }
 
+    @Test
     public void testTransformInvalidFunction() {
         assertThrows(TransformationException.class, () -> subject.transform("*", "90"));
+    }
+
+    @Test
+    public void testTransformDivideByZero() {
+        assertThrows(TransformationException.class, () -> subject.transform("0", "1"));
     }
 }

--- a/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/MultiplyTransformationServiceTest.java
+++ b/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/binding/math/internal/MultiplyTransformationServiceTest.java
@@ -42,10 +42,12 @@ class MultiplyTransformationServiceTest {
         assertEquals("10.0 watt", result);
     }
 
+    @Test
     public void testTransformInvalidSource() {
         assertThrows(TransformationException.class, () -> subject.transform("20", "*"));
     }
 
+    @Test
     public void testTransformInvalidFunction() {
         assertThrows(TransformationException.class, () -> subject.transform("*", "90"));
     }


### PR DESCRIPTION
This is useful for e.g. to display the remaining time of the dishwasher in minutes instead of seconds. This could also be achieved by multiplying with `0.1666667` but having a dedicated transformation for that is more convenient.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>