### PR TITLE
[tr064] fix ignored configuration update

### DIFF
--- a/bundles/org.smarthomej.binding.tr064/src/main/java/org/smarthomej/binding/tr064/internal/Tr064RootHandler.java
+++ b/bundles/org.smarthomej.binding.tr064/src/main/java/org/smarthomej/binding/tr064/internal/Tr064RootHandler.java
@@ -204,6 +204,7 @@ public class Tr064RootHandler extends BaseBridgeHandler implements PhonebookProv
         removeConnectScheduler();
         uninstallPolling();
         stateCache.clear();
+        scpdUtil = null;
 
         super.dispose();
     }
@@ -257,9 +258,10 @@ public class Tr064RootHandler extends BaseBridgeHandler implements PhonebookProv
                 }
 
                 // clear auth cache and force re-auth
-                httpClient.getAuthenticationStore().clearAuthenticationResults();
-                AuthenticationStore auth = httpClient.getAuthenticationStore();
-                auth.addAuthentication(new DigestAuthentication(new URI(endpointBaseURL), Authentication.ANY_REALM,
+                AuthenticationStore authStore = httpClient.getAuthenticationStore();
+                authStore.clearAuthentications();
+                authStore.clearAuthenticationResults();
+                authStore.addAuthentication(new DigestAuthentication(new URI(endpointBaseURL), Authentication.ANY_REALM,
                         config.user, config.password));
 
                 // check & update properties


### PR DESCRIPTION
As reported an updated user/password configuration is ignored until the whole system is restarted. This is because the SCPDUtil is only initialized if it is not set. The field was not nulled on disposal and thus the configuration change was ignored. 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>