### PR TITLE
[transform.basicprofiles] Added Debounce Profile - Counting Strategy

### DIFF
--- a/bundles/org.smarthomej.transform.basicprofiles/README.md
+++ b/bundles/org.smarthomej.transform.basicprofiles/README.md
@@ -42,6 +42,24 @@ Switch lightsStatus {
 }
 ```
 
+## Debounce (Counting) Profile
+
+This Profile counts and skips the number for State changes before it sends an update to the Item.
+It can be used to debounce Item States.
+The number of skipped changes can be defined by the user.
+
+### Configuration
+
+| Configuration Parameter | Type    | Description                                   |
+|-------------------------|---------|-----------------------------------------------|
+| `numberOfChanges`       | integer | Number of changes before updating Item state. |
+
+### Full Example
+
+```java
+Switch debouncedSwitch { channel="xxx" [profile="basic-profiles:debounce-counting"] }
+```
+
 ## Invert / Negate Profile
 
 The Invert / Negate Profile inverts or negates a Command / State.

--- a/bundles/org.smarthomej.transform.basicprofiles/README.md
+++ b/bundles/org.smarthomej.transform.basicprofiles/README.md
@@ -44,15 +44,14 @@ Switch lightsStatus {
 
 ## Debounce (Counting) Profile
 
-This Profile counts and skips the number for State changes before it sends an update to the Item.
+This Profile counts and skips a user-defined number of State changes before it sends an update to the Item.
 It can be used to debounce Item States.
-The number of skipped changes can be defined by the user.
 
 ### Configuration
 
 | Configuration Parameter | Type    | Description                                   |
 |-------------------------|---------|-----------------------------------------------|
-| `numberOfChanges`       | integer | Number of changes before updating Item state. |
+| `numberOfChanges`       | integer | Number of changes before updating Item State. |
 
 ### Full Example
 
@@ -85,7 +84,7 @@ Switch invertedSwitch { channel="xxx" [profile="basic-profiles:invert"] }
 
 ## Round Profile
 
-The Round Profile scales the state to a specific number of decimal places based on the power of ten.
+The Round Profile scales the State to a specific number of decimal places based on the power of ten.
 Optionally the [Rounding mode](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/RoundingMode.html) can be set.
 Source Channels should accept Item Type `Number`.
 

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/config/DebounceCountingStateProfileConfig.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/config/DebounceCountingStateProfileConfig.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.transform.basicprofiles.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.smarthomej.transform.basicprofiles.internal.profiles.DebounceCountingStateProfile;
+
+/**
+ * Configuration for {@link DebounceCountingStateProfile}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class DebounceCountingStateProfileConfig {
+    public int numberOfChanges = 1;
+}

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/factory/BasicProfilesFactory.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/factory/BasicProfilesFactory.java
@@ -42,6 +42,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.smarthomej.transform.basicprofiles.internal.profiles.DebounceCountingStateProfile;
 import org.smarthomej.transform.basicprofiles.internal.profiles.GenericCommandTriggerProfile;
 import org.smarthomej.transform.basicprofiles.internal.profiles.GenericToggleSwitchTriggerProfile;
 import org.smarthomej.transform.basicprofiles.internal.profiles.InvertStateProfile;
@@ -59,6 +60,7 @@ public class BasicProfilesFactory implements ProfileFactory, ProfileTypeProvider
 
     public static final ProfileTypeUID GENERIC_COMMAND_UID = new ProfileTypeUID(SCOPE, "generic-command");
     public static final ProfileTypeUID GENERIC_TOGGLE_SWITCH_UID = new ProfileTypeUID(SCOPE, "toggle-switch");
+    public static final ProfileTypeUID DEBOUNCE_COUNTING_UID = new ProfileTypeUID(SCOPE, "debounce-counting");
     public static final ProfileTypeUID INVERT_UID = new ProfileTypeUID(SCOPE, "invert");
     public static final ProfileTypeUID ROUND_UID = new ProfileTypeUID(SCOPE, "round");
     public static final ProfileTypeUID THRESHOLD_UID = new ProfileTypeUID(SCOPE, "threshold");
@@ -72,6 +74,8 @@ public class BasicProfilesFactory implements ProfileFactory, ProfileTypeProvider
             .newTrigger(GENERIC_COMMAND_UID, "Generic Toggle Switch") //
             .withSupportedItemTypes(CoreItemFactory.SWITCH) //
             .build();
+    private static final ProfileType PROFILE_TYPE_DEBOUNCE_COUNTING = ProfileTypeBuilder
+            .newState(DEBOUNCE_COUNTING_UID, "Debounce (Counting)").build();
     private static final ProfileType PROFILE_TYPE_INVERT = ProfileTypeBuilder.newState(INVERT_UID, "Invert / Negate")
             .withSupportedItemTypes(CoreItemFactory.CONTACT, CoreItemFactory.DIMMER, CoreItemFactory.NUMBER,
                     CoreItemFactory.PLAYER, CoreItemFactory.ROLLERSHUTTER, CoreItemFactory.SWITCH) //
@@ -88,9 +92,10 @@ public class BasicProfilesFactory implements ProfileFactory, ProfileTypeProvider
             .build();
 
     private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Set.of(GENERIC_COMMAND_UID,
-            GENERIC_TOGGLE_SWITCH_UID, INVERT_UID, ROUND_UID, THRESHOLD_UID);
+            GENERIC_TOGGLE_SWITCH_UID, DEBOUNCE_COUNTING_UID, INVERT_UID, ROUND_UID, THRESHOLD_UID);
     private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Set.of(PROFILE_TYPE_GENERIC_COMMAND,
-            PROFILE_TYPE_GENERIC_TOGGLE_SWITCH, PROFILE_TYPE_INVERT, PROFILE_TYPE_ROUND, PROFILE_TYPE_THRESHOLD);
+            PROFILE_TYPE_GENERIC_TOGGLE_SWITCH, PROFILE_TYPE_DEBOUNCE_COUNTING, PROFILE_TYPE_INVERT, PROFILE_TYPE_ROUND,
+            PROFILE_TYPE_THRESHOLD);
 
     private final Map<LocalizedKey, ProfileType> localizedProfileTypeCache = new ConcurrentHashMap<>();
 
@@ -111,6 +116,8 @@ public class BasicProfilesFactory implements ProfileFactory, ProfileTypeProvider
             return new GenericCommandTriggerProfile(callback, context);
         } else if (GENERIC_TOGGLE_SWITCH_UID.equals(profileTypeUID)) {
             return new GenericToggleSwitchTriggerProfile(callback, context);
+        } else if (DEBOUNCE_COUNTING_UID.equals(profileTypeUID)) {
+            return new DebounceCountingStateProfile(callback, context);
         } else if (INVERT_UID.equals(profileTypeUID)) {
             return new InvertStateProfile(callback);
         } else if (ROUND_UID.equals(profileTypeUID)) {

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/profiles/DebounceCountingStateProfile.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/profiles/DebounceCountingStateProfile.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.transform.basicprofiles.internal.profiles;
+
+import static org.smarthomej.transform.basicprofiles.internal.factory.BasicProfilesFactory.DEBOUNCE_COUNTING_UID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.smarthomej.transform.basicprofiles.internal.config.DebounceCountingStateProfileConfig;
+
+/**
+ * Debounces a {@link State} by counting.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class DebounceCountingStateProfile implements StateProfile {
+
+    private final Logger logger = LoggerFactory.getLogger(DebounceCountingStateProfile.class);
+
+    private final ProfileCallback callback;
+
+    private final int numberOfChanges;
+    private int counter;
+
+    private @Nullable State previousState;
+
+    public DebounceCountingStateProfile(ProfileCallback callback, ProfileContext context) {
+        this.callback = callback;
+        DebounceCountingStateProfileConfig config = context.getConfiguration()
+                .as(DebounceCountingStateProfileConfig.class);
+        logger.debug("Configuring profile with parameters: [numberOfChanges='{}']", config.numberOfChanges);
+
+        if (config.numberOfChanges < 0) {
+            throw new IllegalArgumentException(String
+                    .format("numberOfChanges has to be a non-negative integer but was '%d'.", config.numberOfChanges));
+        }
+
+        this.numberOfChanges = config.numberOfChanges;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return DEBOUNCE_COUNTING_UID;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        this.previousState = state;
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        // no-op
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        // no-op
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        logger.debug("Received state update from Handler");
+        State localPreviousState = previousState;
+        if (localPreviousState == null) {
+            callback.sendUpdate(state);
+            previousState = state;
+        } else {
+            if (state.equals(localPreviousState.as(state.getClass()))) {
+                logger.debug("Item state back to previous state, reset counter");
+                callback.sendUpdate(localPreviousState);
+                counter = 0;
+            } else {
+                logger.debug("Item state changed, counting");
+                counter++;
+                if (numberOfChanges < counter) {
+                    logger.debug("Item state has changed {} times, send new state to Item", counter);
+                    callback.sendUpdate(state);
+                    previousState = state;
+                    counter = 0;
+                } else {
+                    callback.sendUpdate(localPreviousState);
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/config/debounce.xml
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/config/debounce.xml
@@ -6,8 +6,8 @@
 
 	<config-description uri="profile:basic-profiles:debounce-counting">
 		<parameter name="numberOfChanges" type="integer" min="0" step="1">
-			<label>Number of Changes</label>
-			<description>Number of changes before updating Item state.</description>
+			<label>Number Of Changes</label>
+			<description>Number of changes before updating Item State.</description>
 			<default>1</default>
 		</parameter>
 	</config-description>

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/config/debounce.xml
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/config/debounce.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="profile:basic-profiles:debounce-counting">
+		<parameter name="numberOfChanges" type="integer" min="0" step="1">
+			<label>Number of Changes</label>
+			<description>Number of changes before updating Item state.</description>
+			<default>1</default>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/i18n/basicprofiles.properties
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/i18n/basicprofiles.properties
@@ -9,8 +9,8 @@ profile.config.basic-profiles.toggle-switch.events.label = Events
 profile.config.basic-profiles.toggle-switch.events.description = Comma separated list of events to which the profile should listen.
 
 profile-type.basic-profiles.debounce-counting.label = Debounce (Counting)
-profile.config.basic-profiles.debounce-counting.scale.label = Number of Changes
-profile.config.basic-profiles.debounce-counting.scale.description = Number of changes before updating Item state.
+profile.config.basic-profiles.debounce-counting.scale.label = Number Of Changes
+profile.config.basic-profiles.debounce-counting.scale.description = Number of changes before updating Item State.
 
 profile-type.basic-profiles.invert.label = Invert / Negate
 

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/i18n/basicprofiles.properties
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/i18n/basicprofiles.properties
@@ -8,6 +8,10 @@ profile-type.basic-profiles.toggle-switch.label = Generic Toggle Switch
 profile.config.basic-profiles.toggle-switch.events.label = Events
 profile.config.basic-profiles.toggle-switch.events.description = Comma separated list of events to which the profile should listen.
 
+profile-type.basic-profiles.debounce-counting.label = Debounce (Counting)
+profile.config.basic-profiles.debounce-counting.scale.label = Number of Changes
+profile.config.basic-profiles.debounce-counting.scale.description = Number of changes before updating Item state.
+
 profile-type.basic-profiles.invert.label = Invert / Negate
 
 profile-type.basic-profiles.round.label = Round

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/i18n/basicprofiles_de.properties
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/i18n/basicprofiles_de.properties
@@ -8,6 +8,10 @@ profile-type.basic-profiles.toggle-switch.label = Generic Toggle Switch
 profile.config.basic-profiles.toggle-switch.events.label = Ereignisse
 profile.config.basic-profiles.toggle-switch.events.description = Kommagetrennte Liste der Ereignisse, die das Profil verfolgen soll.
 
+profile-type.basic-profiles.debounce-counting.label = Debounce (Zähler)
+profile.config.basic-profiles.debounce-counting.scale.label = Anzahl der Änderungen
+profile.config.basic-profiles.debounce-counting.scale.description = Anzahl der Änderungen bevor der Item State aktualisiert wird.
+
 profile-type.basic-profiles.invert.label = Invertieren / Negieren
 
 profile-type.basic-profiles.round.label = Runden

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/i18n/basicprofiles_de.properties
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/resources/OH-INF/i18n/basicprofiles_de.properties
@@ -8,7 +8,7 @@ profile-type.basic-profiles.toggle-switch.label = Generic Toggle Switch
 profile.config.basic-profiles.toggle-switch.events.label = Ereignisse
 profile.config.basic-profiles.toggle-switch.events.description = Kommagetrennte Liste der Ereignisse, die das Profil verfolgen soll.
 
-profile-type.basic-profiles.debounce-counting.label = Debounce (Zähler)
+profile-type.basic-profiles.debounce-counting.label = Entprellen (Zähler)
 profile.config.basic-profiles.debounce-counting.scale.label = Anzahl der Änderungen
 profile.config.basic-profiles.debounce-counting.scale.description = Anzahl der Änderungen bevor der Item State aktualisiert wird.
 

--- a/bundles/org.smarthomej.transform.basicprofiles/src/test/java/org/smarthomej/transform/basicprofiles/internal/factory/BasicProfilesFactoryTest.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/test/java/org/smarthomej/transform/basicprofiles/internal/factory/BasicProfilesFactoryTest.java
@@ -50,7 +50,7 @@ import org.smarthomej.transform.basicprofiles.internal.profiles.ThresholdStatePr
 @NonNullByDefault
 public class BasicProfilesFactoryTest {
 
-    private static final int NUMBER_OF_PROFILES = 5;
+    private static final int NUMBER_OF_PROFILES = 6;
 
     private static final Map<String, Object> PROPERTIES = Map.of(ThresholdStateProfile.PARAM_THRESHOLD, 15,
             RoundStateProfile.PARAM_SCALE, 2, GenericCommandTriggerProfile.PARAM_EVENTS, "1002,1003",

--- a/bundles/org.smarthomej.transform.basicprofiles/src/test/java/org/smarthomej/transform/basicprofiles/internal/profiles/DebouncCountingStateProfileTest.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/test/java/org/smarthomej/transform/basicprofiles/internal/profiles/DebouncCountingStateProfileTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.transform.basicprofiles.internal.profiles;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.types.State;
+
+/**
+ * Debounces a {@link State} by counting.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+class DebouncCountingStateProfileTest {
+
+    public static class ParameterSet {
+        public final List<State> sourceStates;
+        public final List<State> resultingStates;
+        public final int numberOfChanges;
+
+        public ParameterSet(List<State> sourceStates, List<State> resultingStates, int numberOfChanges) {
+            this.sourceStates = sourceStates;
+            this.resultingStates = resultingStates;
+            this.numberOfChanges = numberOfChanges;
+        }
+    }
+
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] { //
+                { new ParameterSet(List.of(OnOffType.ON), List.of(OnOffType.ON), 0) }, //
+                { new ParameterSet(List.of(OnOffType.ON), List.of(OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON), List.of(OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF), List.of(OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.OFF), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.ON, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.ON, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.OFF, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF, OnOffType.OFF), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.OFF, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF, OnOffType.OFF), 1) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.ON, OnOffType.OFF, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.ON, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.ON, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.OFF, OnOffType.ON),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.ON), 2) }, //
+                { new ParameterSet(List.of(OnOffType.ON, OnOffType.OFF, OnOffType.OFF, OnOffType.OFF),
+                        List.of(OnOffType.ON, OnOffType.ON, OnOffType.ON, OnOffType.OFF), 2) } //
+        });
+    }
+
+    private @NonNullByDefault({}) @Mock ProfileCallback mockCallback;
+    private @NonNullByDefault({}) @Mock ProfileContext mockContext;
+
+    @Test
+    public void testWrongParameterLower() {
+        assertThrows(IllegalArgumentException.class, () -> initProfile(-1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testOnStateUpdateFromHandler(ParameterSet parameterSet) {
+        final StateProfile profile = initProfile(parameterSet.numberOfChanges);
+        for (int i = 0; i < parameterSet.sourceStates.size(); i++) {
+            verifySendUpdate(profile, parameterSet.sourceStates.get(i), parameterSet.resultingStates.get(i));
+        }
+    }
+
+    private StateProfile initProfile(int numberOfChanges) {
+        when(mockContext.getConfiguration()).thenReturn(new Configuration(Map.of("numberOfChanges", numberOfChanges)));
+        return new DebounceCountingStateProfile(mockCallback, mockContext);
+    }
+
+    private void verifySendUpdate(StateProfile profile, State state, State expectedState) {
+        reset(mockCallback);
+        profile.onStateUpdateFromHandler(state);
+        verify(mockCallback, times(1)).sendUpdate(eq(expectedState));
+    }
+}


### PR DESCRIPTION
- Added Debounce Profile - Counting Strategy

This is a basic approach to debounce a state update via counting strategy. As mentioned in the related OHC issue there are other strategies to archive similar results too (e.g. time-based debouncing).

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>