### PR TITLE
[deconz] fix window covering support

### DIFF
--- a/bundles/org.smarthomej.binding.deconz/README.md
+++ b/bundles/org.smarthomej.binding.deconz/README.md
@@ -28,7 +28,6 @@ These sensors are supported:
 | Carbon-Monoxide Sensor            | ZHACarbonmonoxide                 | `carbonmonoxide`     |
 | Color Controller                  | ZBT-Remote-ALL-RGBW               | `colorcontrol`       |
 
-
 Additionally lights, window coverings (blinds), door locks and thermostats are supported:
 
 | Device type                          | Resource Type                                 | Thing type              |
@@ -42,6 +41,8 @@ Additionally lights, window coverings (blinds), door locks and thermostats are s
 | Thermostat                           | ZHAThermostat                                 | `thermostat`            |
 | Warning Device (Siren)               | Warning device                                | `warningdevice`         |
 | Door Lock                            | A remotely operatable door lock               | `doorlock`              |
+
+**Note**: `windowcovering` might require updating your deconz software since the support changed.
 
 Currently only light-groups are supported via the thing-type `lightgroup`.
 

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/dto/LightState.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/dto/LightState.java
@@ -45,6 +45,11 @@ public class LightState {
     public @Nullable Integer ct;
     public double @Nullable [] xy;
 
+    // for window covering
+    public @Nullable Boolean open;
+    public @Nullable Boolean stop;
+    public @Nullable Integer lift;
+
     public @Nullable Integer transitiontime;
 
     /**

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/LightThingHandler.java
@@ -267,7 +267,7 @@ public class LightThingHandler extends DeconzBaseThingHandler {
                 } else if (command == StopMoveType.STOP) {
                     newLightState.stop = true;
                 } else if (command instanceof PercentType) {
-                    newLightState.bri = fromPercentType((PercentType) command);
+                    newLightState.lift = ((PercentType) command).intValue();
                 } else {
                     return;
                 }

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/LightThingHandler.java
@@ -263,15 +263,9 @@ public class LightThingHandler extends DeconzBaseThingHandler {
                 break;
             case CHANNEL_POSITION:
                 if (command instanceof UpDownType) {
-                    newLightState.on = (command == UpDownType.DOWN);
+                    newLightState.open = (command == UpDownType.UP);
                 } else if (command == StopMoveType.STOP) {
-                    if (currentOn != null && currentOn && currentBri != null && currentBri <= BRIGHTNESS_MAX) {
-                        // going down or currently stop (254 because of rounding error)
-                        newLightState.on = true;
-                    } else if (currentOn != null && !currentOn && currentBri != null && currentBri > BRIGHTNESS_MIN) {
-                        // going up or currently stopped
-                        newLightState.on = false;
-                    }
+                    newLightState.stop = true;
                 } else if (command instanceof PercentType) {
                     newLightState.bri = fromPercentType((PercentType) command);
                 } else {


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/openhab/openhab-addons/pull/9914 (window coverings do not support `ontime` and this stops the REST API from processing the request). This PR also changes from the deprecated bri/on to lift/open/stop. 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>