### PR TITLE
[androiddebugbridge] Added DynamicCommandOptionsProvider to populate 'start-package' Channel

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/README.md
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/README.md
@@ -48,9 +48,9 @@ The available modes are:
 
 The configuration depends on the application, device and version used.
 
-This is a sample of the mediaStateJSONConfig thing configuration:
+This is a sample of the mediaStateJSONConfig thing configuration - the `label` is optional:
 
-`[{"name": "com.amazon.tv.launcher", "mode": "idle"},{"name": "org.jellyfin.androidtv", "mode": "wake_lock", "wakeLockPlayStates": [2,3]},{"name": "com.amazon.firetv.youtube", "mode": "wake_lock", "wakeLockPlayStates": [2]}]`
+`[{"name": "com.amazon.tv.launcher", "mode": "idle"},{"name": "org.jellyfin.androidtv", "mode": "wake_lock", "wakeLockPlayStates": [2,3]}, {"name": "com.amazon.firetv.youtube", "label":"YouTube", "mode": "wake_lock", "wakeLockPlayStates": [2]}]`
 
 ## Channels
 
@@ -61,7 +61,7 @@ This is a sample of the mediaStateJSONConfig thing configuration:
 | tap  | String | Send tap event to android device (format x,y) |
 | media-volume  | Dimmer | Set or get media volume level on android device |
 | media-control  | Player | Control media on android device |
-| start-package  | String | Run application by package name |
+| start-package  | String | Run application by package name. The commands for this Channel are populated dynamically based on the `mediaStateJSONConfig`. |
 | stop-package  | String | Stop application by package name |
 | stop-open-url  | String | Open a URL with the default application (http, rtsp, aso) |
 | current-package  | String | Package name of the top application in screen |

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDynamicCommandDescriptionProvider.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDynamicCommandDescriptionProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.androiddebugbridge.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.binding.BaseDynamicCommandDescriptionProvider;
+import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.openhab.core.thing.type.DynamicCommandDescriptionProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Dynamic provider of command options.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@Component(service = { DynamicCommandDescriptionProvider.class,
+        AndroidDebugBridgeDynamicCommandDescriptionProvider.class })
+@NonNullByDefault
+public class AndroidDebugBridgeDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
+    @Activate
+    public AndroidDebugBridgeDynamicCommandDescriptionProvider(
+            final @Reference ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
+    }
+}

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandlerFactory.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandlerFactory.java
@@ -22,7 +22,9 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link AndroidDebugBridgeHandlerFactory} is responsible for creating things and thing
@@ -34,6 +36,14 @@ import org.osgi.service.component.annotations.Component;
 @Component(configurationPid = BINDING_CONFIGURATION_PID, service = ThingHandlerFactory.class)
 public class AndroidDebugBridgeHandlerFactory extends BaseThingHandlerFactory {
 
+    private final AndroidDebugBridgeDynamicCommandDescriptionProvider commandDescriptionProvider;
+
+    @Activate
+    public AndroidDebugBridgeHandlerFactory(
+            final @Reference AndroidDebugBridgeDynamicCommandDescriptionProvider commandDescriptionProvider) {
+        this.commandDescriptionProvider = commandDescriptionProvider;
+    }
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES.contains(thingTypeUID);
@@ -43,7 +53,7 @@ public class AndroidDebugBridgeHandlerFactory extends BaseThingHandlerFactory {
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
         if (THING_TYPE_ANDROID_DEVICE.equals(thingTypeUID)) {
-            return new AndroidDebugBridgeHandler(thing);
+            return new AndroidDebugBridgeHandler(thing, commandDescriptionProvider);
         }
         return null;
     }


### PR DESCRIPTION
- Added DynamicCommandOptionsProvider to populate 'start-package' Channel

This feature adds support for starting a package from the UI.

![grafik](https://user-images.githubusercontent.com/5131747/120080380-eac18a80-c0b8-11eb-956d-f6938860bf27.png)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>