### PR TITLE
[snmp] fix initialization exceptions

### DIFF
--- a/bundles/org.smarthomej.binding.snmp/README.md
+++ b/bundles/org.smarthomej.binding.snmp/README.md
@@ -82,6 +82,7 @@ The `target3` thing has additional mandatory parameters: `engineId` and `user`.
 
 The `engineId` must be given in hexadecimal notation (case insensitive) without separators (e.g. `80000009035c710dbcd9e6`).
 The allowed length is 11 to 32 bytes (22 to 64 hex characters).
+If you encounter problems, please check if your agent prefixes the set engine id (e.g. Mikrotik uses `80003a8c04` and appends the set value to that).
 
 The `user` parameter is named "securityName" or "userName" in most agents.
 


### PR DESCRIPTION
SNMP4J throws an IllegalArgumentException (e.g. when an engine is too short). This resulted in ERROR level log messages because initialization of the thing handler failed.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>