### PR TITLE
[tr064] fix noise margin and attenuation values

### DIFF
--- a/bundles/org.smarthomej.binding.tr064/src/main/java/org/smarthomej/binding/tr064/internal/Tr064RootHandler.java
+++ b/bundles/org.smarthomej.binding.tr064/src/main/java/org/smarthomej/binding/tr064/internal/Tr064RootHandler.java
@@ -213,19 +213,25 @@ public class Tr064RootHandler extends BaseBridgeHandler implements PhonebookProv
      * poll remote device for channel values
      */
     private void poll() {
-        channels.forEach((channelUID, channelConfig) -> {
-            if (isLinked(channelUID)) {
-                State state = stateCache.putIfAbsentAndGet(channelUID,
-                        () -> soapConnector.getChannelStateFromDevice(channelConfig, channels, stateCache));
-                if (state != null) {
-                    updateState(channelUID, state);
+        try {
+            channels.forEach((channelUID, channelConfig) -> {
+                if (isLinked(channelUID)) {
+                    State state = stateCache.putIfAbsentAndGet(channelUID,
+                            () -> soapConnector.getChannelStateFromDevice(channelConfig, channels, stateCache));
+                    if (state != null) {
+                        updateState(channelUID, state);
+                    }
                 }
-            }
-        });
+            });
+        } catch (RuntimeException e) {
+            logger.warn("Exception while refreshing remote data for thing '{}':", thing.getUID(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
+                    "Refresh exception: " + e.getMessage());
+        }
     }
 
     /**
-     * establish the connection - get secure port (if avallable), install authentication, get device properties
+     * establish the connection - get secure port (if available), install authentication, get device properties
      *
      * @return true if successful
      */

--- a/bundles/org.smarthomej.binding.tr064/src/main/resources/channels.xml
+++ b/bundles/org.smarthomej.binding.tr064/src/main/resources/channels.xml
@@ -239,25 +239,25 @@
 		<getAction name="GetInfo" argument="NewUpstreamCurrRate"/>
 	</channel>
 	<channel name="dslDownstreamNoiseMargin" label="DSL Downstream Noise Margin">
-		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
+		<item type="Number:Dimensionless" unit="dB" factor="0.1" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
 		<getAction name="GetInfo" argument="NewDownstreamNoiseMargin"/>
 	</channel>
 	<channel name="dslUpstreamNoiseMargin" label="DSL Upstream Noise Margin">
-		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
+		<item type="Number:Dimensionless" unit="dB" factor="0.1" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
 		<getAction name="GetInfo" argument="NewUpstreamNoiseMargin"/>
 	</channel>
 	<channel name="dslDownstreamAttenuation" label="DSL Downstream Attenuation">
-		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
+		<item type="Number:Dimensionless" unit="dB" factor="0.1" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
 		<getAction name="GetInfo" argument="NewDownstreamAttenuation"/>
 	</channel>
 	<channel name="dslUpstreamAttenuation" label="DSL Upstream Attenuation">
-		<item type="Number:Dimensionless" unit="dB" statePattern="%.1f dB"/>
+		<item type="Number:Dimensionless" unit="dB" factor="0.1" statePattern="%.1f dB"/>
 		<service deviceType="urn:dslforum-org:device:WANDevice:1"
 			serviceId="urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1"/>
 		<getAction name="GetInfo" argument="NewUpstreamAttenuation"/>

--- a/bundles/org.smarthomej.binding.tr064/src/main/resources/xsd/channeltypes.xsd
+++ b/bundles/org.smarthomej.binding.tr064/src/main/resources/xsd/channeltypes.xsd
@@ -6,6 +6,7 @@
             <xs:extension base="xs:string">
                 <xs:attribute type="xs:string" name="type" use="required"/>
                 <xs:attribute type="xs:string" name="unit" default=""/>
+                <xs:attribute type="xs:decimal" name="factor"/>
                 <xs:attribute type="xs:string" name="statePattern"/>
             </xs:extension>
         </xs:simpleContent>


### PR DESCRIPTION
As reported the values for upstream/downstream noise margin and attenuation were wrong by a factor of 10. The reason is that AVM reports 0.1 dB instead of the used dB.