### PR TITLE
[androiddebugbridge] exception handling

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -399,9 +399,10 @@ public class AndroidDebugBridgeDevice {
                     do {
                         byteArrayOutputStream.writeBytes(stream.read());
                     } while (!stream.isClosed());
-                } catch (IOException e) {
+                } catch (IOException | IllegalStateException e) {
                     String message = e.getMessage();
-                    if (message != null && !"Stream closed".equals(message)) {
+                    if (message != null && !"Stream closed".equals(message)
+                            && !"connect() must be called first".equals(message)) {
                         throw e;
                     }
                 }


### PR DESCRIPTION
changed: exception handling

If a device is not connected the binding throws an exception on any command.
The binding knows the device is offline so there is no reason to throw an exception.

Signed-off-by: Tom Blum trinitus01@googlemail.com