### PR TITLE
[androiddebugbridge] exception handling

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -399,9 +399,10 @@ public class AndroidDebugBridgeDevice {
                     do {
                         byteArrayOutputStream.writeBytes(stream.read());
                     } while (!stream.isClosed());
-                } catch (IOException e) {
+                } catch (IOException | IllegalStateException e) {
                     String message = e.getMessage();
-                    if (message != null && !"Stream closed".equals(message)) {
+                    if (message != null && !"Stream closed".equals(message)
+                            && !"connect() must be called first".equals(message)) {
                         throw e;
                     }
                 }


### PR DESCRIPTION
changed: exception handling

If a device is not connected it throws an exception.
But the binding still knows the device is not connected and shows it in the UI.
So there is no reason to throw any exception anymore.

Signed-off-by: Tom Blum trinitus01@googlemail.com