### PR TITLE
[tr064] allow skipping digits from left in phonebook lookup

### DIFF
--- a/bundles/org.smarthomej.binding.tr064/README.md
+++ b/bundles/org.smarthomej.binding.tr064/README.md
@@ -178,6 +178,7 @@ If only a specific phonebook from the device should be used, this can be specifi
 The default is to use all available phonebooks from the specified thing.
 In case the format of the number in the phonebook and the format of the number from the channel are different (e.g. regarding country prefixes), the `matchCount` parameter can be used.
 The configured `matchCount` is counted from the right end and denotes the number of matching characters needed to consider this number as matching.
+Negative `matchCount` values skip digits from the left (e.g. if the input number is `033998005671` a `matchCount` of `-1` would remove the leading `0` ).
 A `matchCount` of `0` is considered as "match everything".
 Matching is done on normalized versions of the numbers that have all characters except digits, '+' and '*' removed.
 There is an optional configuration parameter called `phoneNumberIndex` that should be used when linking to a channel with item type `StringListType` (like `Call` in the example below), which determines which number to be picked, i.e. to or from.
@@ -191,7 +192,8 @@ The phonebooks of a `fritzbox` thing can be used to lookup a number from rules v
 `phonebook` and `matchCount` are optional parameters.
 You can omit one or both of these parameters.
 The configured `matchCount` is counted from the right end and denotes the number of matching characters needed to consider this number as matching.
-A `matchCount` of `0` is considered as "match everything" and is used as default if no other value is given. 
+Negative `matchCount` values skip digits from the left (e.g. if the input number is `033998005671` a `matchCount` of `-1` would remove the leading `0` ).
+A `matchCount` of `0` is considered as "match everything" and is used as default if no other value is given.
 As in the phonebook profile, matching is done on normalized versions of the numbers that have all characters except digits, '+' and '*' removed.
 The return value is either the phonebook entry (if found) or the input number.
 

--- a/bundles/org.smarthomej.binding.tr064/src/main/java/org/smarthomej/binding/tr064/internal/phonebook/Tr064PhonebookImpl.java
+++ b/bundles/org.smarthomej.binding.tr064/src/main/java/org/smarthomej/binding/tr064/internal/phonebook/Tr064PhonebookImpl.java
@@ -34,7 +34,7 @@ import org.smarthomej.binding.tr064.internal.util.Util;
 public class Tr064PhonebookImpl implements Phonebook {
     private final Logger logger = LoggerFactory.getLogger(Tr064PhonebookImpl.class);
 
-    private Map<String, String> phonebook = new HashMap<>();
+    protected Map<String, String> phonebook = new HashMap<>();
 
     private final HttpClient httpClient;
     private final String phonebookUrl;
@@ -84,9 +84,14 @@ public class Tr064PhonebookImpl implements Phonebook {
     @Override
     public Optional<String> lookupNumber(String number, int matchCount) {
         String normalized = normalizeNumber(number);
-        String matchString = matchCount > 0 && matchCount < normalized.length()
-                ? normalized.substring(normalized.length() - matchCount)
-                : normalized;
+        String matchString;
+        if (matchCount > 0 && matchCount < normalized.length()) {
+            matchString = normalized.substring(normalized.length() - matchCount);
+        } else if (matchCount < 0 && (-matchCount) < normalized.length()) {
+            matchString = normalized.substring(-matchCount);
+        } else {
+            matchString = normalized;
+        }
         logger.trace("Normalized '{}' to '{}', matchString is '{}'", number, normalized, matchString);
         return matchString.isBlank() ? Optional.empty()
                 : phonebook.keySet().stream().filter(n -> n.endsWith(matchString)).findFirst().map(phonebook::get);

--- a/bundles/org.smarthomej.binding.tr064/src/main/resources/OH-INF/config/phonebookProfile.xml
+++ b/bundles/org.smarthomej.binding.tr064/src/main/resources/OH-INF/config/phonebookProfile.xml
@@ -9,9 +9,10 @@
 			<label>Phone book</label>
 			<description>The name of the the phone book</description>
 		</parameter>
-		<parameter name="matchCount" type="integer" min="0" step="1">
+		<parameter name="matchCount" type="integer" step="1">
 			<label>Match Count</label>
-			<description>The number of digits matching the incoming value, counted from far right (default is 0 = all matching)</description>
+			<description>The number of digits matching the incoming value, counted from far right (default is 0 = all matching).
+				Negative numbers skip digits from the left.</description>
 			<default>0</default>
 		</parameter>
 		<parameter name="phoneNumberIndex" type="integer" min="0" max="1" step="1">


### PR DESCRIPTION
Positive `matchCount` values match a defined number of digits from the right (end) of the phonenumber. Negative `matchCount` values skip digits from the left (e.g. for removing international or national prefixes).

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>