### PR TITLE
[mail] add mail content processing

### DIFF
--- a/bundles/org.smarthomej.binding.mail/README.md
+++ b/bundles/org.smarthomej.binding.mail/README.md
@@ -40,15 +40,41 @@ Default ports are `143` (for `PLAIN` and `STARTTLS`) and `993` (for `SSL`) in th
 ## Channels
 
 There are no channels for the `smtp` thing.
-The `imap` and `pop3` things can be extended with `mailcount`-type channels.
+The `imap` and `pop3` things can be extended with `mailcount`- and `content`-type channels.
 
 ### Type `mailcount`
 
 Each channel has two parameters: `folder` and `type`.
+
 The `folder` is mandatory and denotes the folder name on the given account.
 You can either use the root folder like (e.g. "INBOX") or a sub directory of your structure (e.g. "INBOX.Sent" or "INBOX.Junk").
+
 The `type` parameter can be `UNREAD` or `TOTAL` (default).
 Channels with type `UNREAD` give the number on unread mails in that folder.
+
+### Type `content`
+
+The `content` type channel presents the contents of an unread mail.
+If the message is a MIME-multipart message, all parts are concatenated.
+The content is converted to a plain string without processing (i.e. HTML tags are still present).
+In most cases the mail content needs further processing in rules to trigger appropriate action.
+
+Each channel has five parameters: `folder`, `subject`, `sender`, `transformation` and `markAsRead`.
+
+The `folder` is mandatory and denotes the folder name on the given account.
+You can either use the root folder like (e.g. "INBOX") or a sub directory of your structure (e.g. "INBOX.Sent" or "INBOX.Junk").
+
+`subject` and `sender` can be used to filter the messages that are processed by the channel.
+Filters use regular expressions (e.g. `.*DHL.*` as `sender` would match all From-addresses that contain "DHL").
+If a parameter is left empty, no filter is applied. 
+
+The `transformation` is applied before setting the channel status.
+Transformations can be chained by separating them with the mathematical intersection character "∩", e.g. `REGEX:.*Shipment-Status: ([a-z]+).*∩MAP:status.map` would first extract a character string with a regular expression and then apply the given MAP transformation on the result.
+Please note that the values will be discarded if one transformation fails (e.g. REGEX did not match).
+This means that you can also use it to filter certain emails e.g. `REGEX:(.*Sendungsbenachrichtigung.*)` would only match for mails containing the string "Sendungsbenachrichtigung" but output the whole message.
+
+Since with each refresh all unread mails are processed the same message content would be sent to the channel multiple times.
+This can be prevented by setting `markAsRead` to `true` (default is `false`), which marks all processed messages as read.
 
 ## Full Example
 
@@ -61,6 +87,7 @@ Thing mail:imap:sampleimap [ hostname="imap.example.com", security="SSL", userna
     Channels:
         Type mailcount : inbox_total [ folder="INBOX", type="TOTAL" ]
         Type mailcount : inbox_unread [ folder="INBOX", type="UNREAD" ]
+        Type content : fedex_notification [ folder="INBOX" sender="Fedex.*" markAsRead="true" ]
 }
 ```
 
@@ -69,6 +96,7 @@ mail.items:
 ```
 Number InboxTotal  "INBOX [%d]"        { channel="mail:imap:sampleimap:inbox_total" }
 Number InboxUnread "INBOX Unread [%d]" { channel="mail:imap:sampleimap:inbox_unread" }
+String FedexNotification               { channel="mail:imap:sampleimap:fedex_notification" }
 ```
 
 mail.sitemap:

--- a/bundles/org.smarthomej.binding.mail/pom.xml
+++ b/bundles/org.smarthomej.binding.mail/pom.xml
@@ -15,8 +15,7 @@
   <name>SmartHome/J Add-ons :: Bundles :: Mail Binding</name>
 
   <properties>
-    <!-- TODO: revert embedding -->
-    <!-- dep.noembedding>javax.mail</dep.noembedding -->
+    <dep.noembedding>javax.mail</dep.noembedding>
     <bnd.importpackage>sun.security.util;resolution:=optional</bnd.importpackage>
   </properties>
 
@@ -37,8 +36,7 @@
       <groupId>org.smarthomej.addons.bundles</groupId>
       <artifactId>org.smarthomej.commons</artifactId>
       <version>3.1.3-SNAPSHOT</version>
-      <!-- TODO: revert to provided -->
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/bundles/org.smarthomej.binding.mail/pom.xml
+++ b/bundles/org.smarthomej.binding.mail/pom.xml
@@ -15,7 +15,8 @@
   <name>SmartHome/J Add-ons :: Bundles :: Mail Binding</name>
 
   <properties>
-    <dep.noembedding>javax.mail</dep.noembedding>
+    <!-- TODO: revert embedding -->
+    <!-- dep.noembedding>javax.mail</dep.noembedding -->
     <bnd.importpackage>sun.security.util;resolution:=optional</bnd.importpackage>
   </properties>
 
@@ -30,6 +31,13 @@
       <groupId>com.sun.mail</groupId>
       <artifactId>javax.mail</artifactId>
       <version>1.6.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.smarthomej.addons.bundles</groupId>
+      <artifactId>org.smarthomej.commons</artifactId>
+      <version>3.1.3-SNAPSHOT</version>
+      <!-- TODO: revert to provided -->
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.smarthomej.binding.mail/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.mail/src/main/feature/feature.xml
@@ -6,6 +6,7 @@
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true">mvn:com.sun.mail/javax.mail/1.6.2</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>
+		<bundle dependency="true">mvn:org.smarthomej.addons.bundles/org.smarthomej.commons/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.mail/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/MailBindingConstants.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/MailBindingConstants.java
@@ -39,4 +39,5 @@ public class MailBindingConstants {
             Arrays.asList(THING_TYPE_SMTPSERVER, THING_TYPE_IMAPSERVER, THING_TYPE_POP3SERVER));
 
     public static final ChannelTypeUID CHANNEL_TYPE_UID_FOLDER_MAILCOUNT = new ChannelTypeUID(BINDING_ID, "mailcount");
+    public static final ChannelTypeUID CHANNEL_TYPE_UID_MAIL_CONTENT = new ChannelTypeUID(BINDING_ID, "content");
 }

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/MailHandlerFactory.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/MailHandlerFactory.java
@@ -22,7 +22,10 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BaseThingHandlerFactory;
 import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.smarthomej.commons.transform.ValueTransformationProvider;
 
 /**
  * The {@link MailHandlerFactory} is responsible for creating things and thing
@@ -33,6 +36,13 @@ import org.osgi.service.component.annotations.Component;
 @NonNullByDefault
 @Component(configurationPid = "binding.mail", service = ThingHandlerFactory.class)
 public class MailHandlerFactory extends BaseThingHandlerFactory {
+
+    private final ValueTransformationProvider valueTransformationProvider;
+
+    @Activate
+    public MailHandlerFactory(@Reference ValueTransformationProvider valueTransformationProvider) {
+        this.valueTransformationProvider = valueTransformationProvider;
+    }
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -46,7 +56,7 @@ public class MailHandlerFactory extends BaseThingHandlerFactory {
         if (THING_TYPE_SMTPSERVER.equals(thingTypeUID)) {
             return new SMTPHandler(thing);
         } else if (THING_TYPE_IMAPSERVER.equals(thingTypeUID) || THING_TYPE_POP3SERVER.equals(thingTypeUID)) {
-            return new POP3IMAPHandler(thing);
+            return new POP3IMAPHandler(thing, valueTransformationProvider);
         }
 
         return null;

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/POP3IMAPHandler.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/POP3IMAPHandler.java
@@ -32,7 +32,6 @@ import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.Store;
 import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
 import javax.mail.search.FlagTerm;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/POP3IMAPHandler.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/POP3IMAPHandler.java
@@ -121,6 +121,9 @@ public class POP3IMAPHandler extends BaseThingHandler {
     }
 
     private void refresh() {
+        if (Thread.currentThread().isInterrupted()) {
+            return;
+        }
         Properties props = new Properties();
         props.setProperty("mail." + baseProtocol + ".starttls.enable", "true");
         props.setProperty("mail.store.protocol", protocol);
@@ -159,7 +162,7 @@ public class POP3IMAPHandler extends BaseThingHandler {
                         logger.info("missing or empty folder name in channel '{}'", channel.getUID());
                     } else {
                         try (Folder mailbox = store.getFolder(folderName)) {
-                            mailbox.open(Folder.READ_ONLY);
+                            mailbox.open(channelConfig.markAsRead ? Folder.READ_WRITE : Folder.READ_ONLY);
                             Message[] messages = mailbox.search(new FlagTerm(new Flags(Flags.Flag.SEEN), false));
                             for (Message message : messages) {
                                 String subject = message.getSubject();
@@ -186,7 +189,6 @@ public class POP3IMAPHandler extends BaseThingHandler {
                                 } else {
                                     logger.debug("Subject '{}' did not match subject filter.", subject);
                                 }
-                                // message.setFlag(Flags.Flag.SEEN, true);
                             }
                         } catch (MessagingException | IOException e) {
                             throw e;

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/POP3IMAPHandler.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/POP3IMAPHandler.java
@@ -31,6 +31,7 @@ import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.Store;
+import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.search.FlagTerm;
 
@@ -184,9 +185,9 @@ public class POP3IMAPHandler extends BaseThingHandler {
                                 if (rawContent instanceof String) {
                                     logger.trace("Detected plain text message");
                                     contentAsString = (String) rawContent;
-                                } else if (rawContent instanceof MimeMultipart) {
+                                } else if (rawContent instanceof MimeMessage) {
                                     logger.trace("Detected MIME multipart message");
-                                    MimeMultipart mimeMessage = (MimeMultipart) rawContent;
+                                    MimeMessage mimeMessage = (MimeMessage) rawContent;
                                     ByteArrayOutputStream os = new ByteArrayOutputStream();
                                     mimeMessage.writeTo(os);
                                     contentAsString = os.toString();

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/config/POP3IMAPContentChannelConfig.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/config/POP3IMAPContentChannelConfig.java
@@ -27,4 +27,6 @@ public class POP3IMAPContentChannelConfig {
     public @Nullable String folder;
     public String subject = ".*";
     public @Nullable String transformation;
+
+    public boolean markAsRead = false;
 }

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/config/POP3IMAPContentChannelConfig.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/config/POP3IMAPContentChannelConfig.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.mail.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link POP3IMAPContentChannelConfig} class contains fields mapping thing configuration parameters.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+
+@NonNullByDefault
+public class POP3IMAPContentChannelConfig {
+    public @Nullable String folder;
+    public String subject = ".*";
+    public @Nullable String transformation;
+}

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/config/POP3IMAPContentChannelConfig.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/config/POP3IMAPContentChannelConfig.java
@@ -25,7 +25,8 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class POP3IMAPContentChannelConfig {
     public @Nullable String folder;
-    public String subject = ".*";
+    public String subject = "";
+    public String sender = "";
     public @Nullable String transformation;
 
     public boolean markAsRead = false;

--- a/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/config/POP3IMAPMailCountChannelConfig.java
+++ b/bundles/org.smarthomej.binding.mail/src/main/java/org/smarthomej/binding/mail/internal/config/POP3IMAPMailCountChannelConfig.java
@@ -18,13 +18,13 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.smarthomej.binding.mail.internal.MailCountChannelType;
 
 /**
- * The {@link POP3IMAPChannelConfig} class contains fields mapping thing configuration parameters.
+ * The {@link POP3IMAPMailCountChannelConfig} class contains fields mapping thing configuration parameters.
  *
  * @author Jan N. Klug - Initial contribution
  */
 
 @NonNullByDefault
-public class POP3IMAPChannelConfig {
+public class POP3IMAPMailCountChannelConfig {
     public @Nullable String folder;
     public MailCountChannelType type = MailCountChannelType.TOTAL;
 }

--- a/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/i18n/mail_de.properties
+++ b/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/i18n/mail_de.properties
@@ -1,16 +1,16 @@
 # binding
 binding.mail.name = Mail Binding
-binding.mail.description = Unterstützung von POP3, IMAP und SMTP Servern
+binding.mail.description = UnterstÃ¼tzung von POP3, IMAP und SMTP Servern
 
 # thing types
 thing-type.mail.smtp.label = SMTP Server
 thing-type.mail.smtp.description = Wird zum Versenden von E-Mails verwendet
 thing-type.config.mail.smtp.sender.label = Absender
-thing-type.config.mail.smtp.sender.description = Standard-Absender für E-Mails
+thing-type.config.mail.smtp.sender.description = Standard-Absender fÃ¼r E-Mails
 thing-type.config.mail.smtp.hostname.label = IP-Adresse
 thing-type.config.mail.smtp.hostname.description = IP-Adresse oder Hostname des SMTP Servers
 thing-type.config.mail.smtp.port.label = Port
-thing-type.config.mail.smtp.port.description = Standard Ports sind 25 für PLAIN/STARTTLS und 465 für SSL/TLS
+thing-type.config.mail.smtp.port.description = Standard Ports sind 25 fÃ¼r PLAIN/STARTTLS und 465 fÃ¼r SSL/TLS
 thing-type.config.mail.smtp.security.label = Sicherheitsprotokoll
 thing-type.config.mail.smtp.security.description = Server Sicherheitsprotokoll zur Kommunikation mit dem SMTP Server
 thing-type.config.mail.smtp.username.label = Benutzer
@@ -19,42 +19,55 @@ thing-type.config.mail.smtp.password.label = Passwort
 thing-type.config.mail.smtp.password.description = Passwort zur Authentifizierung am SMTP Server
 
 thing-type.mail.imap.label = IMAP Server
-thing-type.mail.imap.description = IMAP Postfach Überwachung
+thing-type.mail.imap.description = IMAP Postfach Ãœberwachung
 thing-type.config.mail.imap.hostname.label = IP-Adresse
 thing-type.config.mail.imap.hostname.description = IP-Adresse oder Hostname des IMAP Servers
 thing-type.config.mail.imap.port.label = Port
-thing-type.config.mail.imap.port.description = Standard Ports sind 143 für PLAIN/STARTTLS und 993 für SSL/TLS
+thing-type.config.mail.imap.port.description = Standard Ports sind 143 fÃ¼r PLAIN/STARTTLS und 993 fÃ¼r SSL/TLS.
 thing-type.config.mail.imap.security.label = Sicherheitsprotokoll
-thing-type.config.mail.imap.security.description = Server Sicherheitsprotokoll zur Kommunikation mit dem IMAP Server
+thing-type.config.mail.imap.security.description = Server Sicherheitsprotokoll zur Kommunikation mit dem IMAP Server.
 thing-type.config.mail.imap.username.label = Benutzer
-thing-type.config.mail.imap.username.description = Benutzer zur Authentifizierung am IMAP Server
+thing-type.config.mail.imap.username.description = Benutzer zur Authentifizierung am IMAP Server.
 thing-type.config.mail.imap.password.label = Passwort
-thing-type.config.mail.imap.password.description = Passwort zur Authentifizierung am IMAP Server
+thing-type.config.mail.imap.password.description = Passwort zur Authentifizierung am IMAP Server.
 thing-type.config.mail.imap.refresh.label = Abfrageintervall
-thing-type.config.mail.imap.refresh.description = Zeit zwischen zwei Abfragen (in s, Standard ist 60s)
+thing-type.config.mail.imap.refresh.description = Zeit zwischen zwei Abfragen (in s, Standard ist 60s).
 
 thing-type.mail.pop3.label = POP3 Server
-thing-type.mail.pop3.description = POP3 Postfach Überwachung
+thing-type.mail.pop3.description = POP3 Postfach Ãœberwachung.
 thing-type.config.mail.pop3.hostname.label = IP-Adresse
-thing-type.config.mail.pop3.hostname.description = IP-Adresse oder Hostname des POP3 Servers
+thing-type.config.mail.pop3.hostname.description = IP-Adresse oder Hostname des POP3 Servers.
 thing-type.config.mail.pop3.port.label = Port
-thing-type.config.mail.pop3.port.description = Standard Ports sind 110 für PLAIN/STARTTLS und 995 für SSL/TLS
+thing-type.config.mail.pop3.port.description = Standard Ports sind 110 fÃ¼r PLAIN/STARTTLS und 995 fÃ¼r SSL/TLS.
 thing-type.config.mail.pop3.security.label = Sicherheitsprotokoll
-thing-type.config.mail.pop3.security.description = Server Sicherheitsprotokoll zur Kommunikation mit dem POP3 Server
+thing-type.config.mail.pop3.security.description = Server Sicherheitsprotokoll zur Kommunikation mit dem POP3 Server.
 thing-type.config.mail.pop3.username.label = Benutzer
-thing-type.config.mail.pop3.username.description = Benutzer zur Authentifizierung am POP3 Server
+thing-type.config.mail.pop3.username.description = Benutzer zur Authentifizierung am POP3 Server.
 thing-type.config.mail.pop3.password.label = Passwort
-thing-type.config.mail.pop3.password.description = Passwort zur Authentifizierung am POP3 Server
+thing-type.config.mail.pop3.password.description = Passwort zur Authentifizierung am POP3 Server.
 thing-type.config.mail.pop3.refresh.label = Abfrageintervall
-thing-type.config.mail.pop3.refresh.description = Zeit zwischen zwei Abfragen (in s, Standard ist 60s)
+thing-type.config.mail.pop3.refresh.description = Zeit zwischen zwei Abfragen (in s, Standard ist 60s).
 
 channel-type.mail.mailcount.label = Anzahl
-channel-type.mail.mailcount.description = Anzahl der E-Mails im Postfach
+channel-type.mail.mailcount.description = Anzahl der E-Mails im Postfach.
 channel-type.config.mail.mailcount.folder.label = Postfach
-channel-type.config.mail.mailcount.folder.description = Name des Postfachs auf dem Server
+channel-type.config.mail.mailcount.folder.description = Name des Postfachs auf dem Server.
 channel-type.config.mail.mailcount.type.label = Typ
 channel-type.config.mail.mailcount.type.option.TOTAL = Gesamt
 channel-type.config.mail.mailcount.type.option.UNREAD = Ungelesen
+
+channel-type.mail.content.label = Inhalt
+channel-type.mail.content.description = Mail-Inhalt als Zeichenkette (mit Betreff-Filter und Inhalts-Transformation).
+channel-type.config.mail.content.folder.label = Postfach
+channel-type.config.mail.content.folder.description = Name des Postfachs auf dem Server.
+channel-type.config.mail.content.subject.label = Betreff Filter
+channel-type.config.mail.content.subject.description = Ein (Regular Expression) Filter fÃ¼r die Betreffzeile.
+channel-type.config.mail.content.sender.label = Absender Filter
+channel-type.config.mail.content.sender.description = Ein (Regular Expression) Filter fÃ¼r die Absender-Adresse.
+channel-type.config.mail.content.transformation.label = Transformation
+channel-type.config.mail.content.transformation.description = Transformationsmuster fÃ¼r die Bearbeitung von Nachrichten. Mehrere Transformationen kÃ¶nnen mit "âˆ©" verkettet werden.
+channel-type.config.mail.content.markAsRead.label = Als Gelesen Markieren
+channel-type.config.mail.content.markAsRead.description = Markiert eine Nachricht nach der Bearbeitung als gelesen und verhindert so doppelte Bearbeitung.
 
 # actions
 sendMessageActionLabel = eine E-Mail senden
@@ -63,8 +76,8 @@ sendMessageActionDescription = Sendet eine E-Mail.
 sendAttachmentMessageActionLabel = eine E-Mail mit Anhang senden
 sendAttachmentMessageActionDescription = Sendet eine E-Mail mit Anhang.
 
-sendAttachmentsMessageActionLabel = eine E-Mail mit mehreren Anhängen senden
-sendAttachmentsMessageActionDescription = Sendet eine E-Mail mit mehreren Anhängen.
+sendAttachmentsMessageActionLabel = eine E-Mail mit mehreren AnhÃ¤ngen senden
+sendAttachmentsMessageActionDescription = Sendet eine E-Mail mit mehreren AnhÃ¤ngen.
 
 sendHTMLMessageActionLabel = eine HTML E-Mail senden
 sendHTMLMessageActionDescription = Sendet eine HTML E-Mail.
@@ -72,5 +85,5 @@ sendHTMLMessageActionDescription = Sendet eine HTML E-Mail.
 sendHTMLAttachmentMessageActionLabel = eine HTML E-Mail mit Anhang senden
 sendHTMLAttachmentMessageActionDescription = Sendet eine HTML E-Mail mit Anhang.
 
-sendHTMLAttachmentsMessageActionLabel = eine HTML E-Mail mit mehreren Anhängen senden
-sendHTMLAttachmentsMessageActionDescription = Sendet eine HTML E-Mail mit mehreren Anhängen.
+sendHTMLAttachmentsMessageActionLabel = eine HTML E-Mail mit mehreren AnhÃ¤ngen senden
+sendHTMLAttachmentsMessageActionDescription = Sendet eine HTML E-Mail mit mehreren AnhÃ¤ngen.

--- a/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/i18n/mail_de.properties
+++ b/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/i18n/mail_de.properties
@@ -57,7 +57,7 @@ channel-type.config.mail.mailcount.type.option.TOTAL = Gesamt
 channel-type.config.mail.mailcount.type.option.UNREAD = Ungelesen
 
 channel-type.mail.content.label = Inhalt
-channel-type.mail.content.description = Mail-Inhalt als Zeichenkette (mit Betreff-Filter und Inhalts-Transformation).
+channel-type.mail.content.description = Inhalt der E-Mail als Zeichenkette (mit Betreff Filter und Inhalts-Transformation).
 channel-type.config.mail.content.folder.label = Postfach
 channel-type.config.mail.content.folder.description = Name des Postfachs auf dem Server.
 channel-type.config.mail.content.subject.label = Betreff Filter

--- a/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/thing/thing-types.xml
@@ -15,12 +15,12 @@
 			<parameter name="hostname" type="text" required="true">
 				<label>Server Hostname</label>
 			</parameter>
-			<parameter name="port" type="text" required="false">
+			<parameter name="port" type="text">
 				<label>Server Port</label>
 				<description>Default values are 25 for plain/STARTTLS and 465 for SSL/TLS</description>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="security" type="text" required="false">
+			<parameter name="security" type="text">
 				<label>SMTP Security Protocol</label>
 				<options>
 					<option value="PLAIN">plain</option>
@@ -30,10 +30,10 @@
 				<limitToOptions>true</limitToOptions>
 				<default>PLAIN</default>
 			</parameter>
-			<parameter name="username" type="text" required="false">
+			<parameter name="username" type="text">
 				<label>SMTP Server Username</label>
 			</parameter>
-			<parameter name="password" type="text" required="false">
+			<parameter name="password" type="text">
 				<label>SMTP Server Password</label>
 				<context>password</context>
 			</parameter>
@@ -46,12 +46,12 @@
 			<parameter name="hostname" type="text" required="true">
 				<label>Server Hostname</label>
 			</parameter>
-			<parameter name="port" type="text" required="false">
+			<parameter name="port" type="text">
 				<label>Server Port</label>
 				<description>Default values are 143 for plain/STARTTLS and 993 for SSL/TLS</description>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="security" type="text" required="false">
+			<parameter name="security" type="text">
 				<label>SMTP Security Protocol</label>
 				<options>
 					<option value="PLAIN">plain</option>
@@ -68,7 +68,7 @@
 				<label>SMTP Server Password</label>
 				<context>password</context>
 			</parameter>
-			<parameter name="refresh" type="integer" required="false" unit="s">
+			<parameter name="refresh" type="integer" unit="s">
 				<label>Refresh Time</label>
 				<description>Refresh time for this account</description>
 				<default>60</default>
@@ -82,12 +82,12 @@
 			<parameter name="hostname" type="text" required="true">
 				<label>Server Hostname</label>
 			</parameter>
-			<parameter name="port" type="text" required="false">
+			<parameter name="port" type="text">
 				<label>Server Port</label>
 				<description>Default values are 110 for plain/STARTTLS and 995 for SSL/TLS</description>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="security" type="text" required="false">
+			<parameter name="security" type="text">
 				<label>SMTP Security Protocol</label>
 				<options>
 					<option value="PLAIN">plain</option>
@@ -104,7 +104,7 @@
 				<label>SMTP Server Password</label>
 				<context>password</context>
 			</parameter>
-			<parameter name="refresh" type="integer" required="false" unit="s">
+			<parameter name="refresh" type="integer" unit="s">
 				<label>Refresh Time</label>
 				<description>Refresh time for this account</description>
 				<default>60</default>
@@ -120,9 +120,8 @@
 		<config-description>
 			<parameter name="folder" type="text" required="true">
 				<label>Folder Name</label>
-				<required>true</required>
 			</parameter>
-			<parameter name="type" type="text" required="false">
+			<parameter name="type" type="text">
 				<options>
 					<option value="UNREAD">Unread</option>
 					<option value="TOTAL">Total</option>
@@ -141,7 +140,6 @@
 		<config-description>
 			<parameter name="folder" type="text" required="true">
 				<label>Folder Name</label>
-				<required>true</required>
 			</parameter>
 			<parameter name="subject" type="text">
 				<label>Subject Filter</label>

--- a/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/thing/thing-types.xml
@@ -135,7 +135,8 @@
 
 	<channel-type id="content">
 		<item-type>String</item-type>
-		<label>Mail Content</label>
+		<label>Content</label>
+		<description>Mail content as String (with subject filter and content transformation).</description>
 		<state readOnly="true"/>
 		<config-description>
 			<parameter name="folder" type="text" required="true">
@@ -145,7 +146,10 @@
 			<parameter name="subject" type="text">
 				<label>Subject Filter</label>
 				<description>A (regular expression) filter for the mail subject.</description>
-				<default>.*</default>
+			</parameter>
+			<parameter name="sender" type="text">
+				<label>Sender Filter</label>
+				<description>A (regular expression) filter for the mail sender address.</description>
 			</parameter>
 			<parameter name="transformation" type="text">
 				<label>Transformation</label>

--- a/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/thing/thing-types.xml
@@ -39,7 +39,7 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-	<thing-type id="imap" extensible="mailcount">
+	<thing-type id="imap" extensible="mailcount,content">
 		<label>IMAP Server</label>
 		<description>Used for receiving emails</description>
 		<config-description>
@@ -75,7 +75,7 @@
 			</parameter>
 		</config-description>
 	</thing-type>
-	<thing-type id="pop3" extensible="mailcount">
+	<thing-type id="pop3" extensible="mailcount,content">
 		<label>POP3 Server</label>
 		<description>Used for receiving emails</description>
 		<config-description>
@@ -129,6 +129,26 @@
 				</options>
 				<limitToOptions>true</limitToOptions>
 				<default>TOTAL</default>
+			</parameter>
+		</config-description>
+	</channel-type>
+
+	<channel-type id="content">
+		<item-type>String</item-type>
+		<label>Mail Content</label>
+		<state readOnly="true"/>
+		<config-description>
+			<parameter name="folder" type="text" required="true">
+				<label>Folder Name</label>
+				<required>true</required>
+			</parameter>
+			<parameter name="subject" type="text">
+				<label>Subject Filter</label>
+				<description>A filter for the mail subject.</description>
+				<default>.*</default>
+			</parameter>
+			<parameter name="transformation" type="text">
+				<label>Transformation</label>
 			</parameter>
 		</config-description>
 	</channel-type>

--- a/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.mail/src/main/resources/OH-INF/thing/thing-types.xml
@@ -144,11 +144,17 @@
 			</parameter>
 			<parameter name="subject" type="text">
 				<label>Subject Filter</label>
-				<description>A filter for the mail subject.</description>
+				<description>A (regular expression) filter for the mail subject.</description>
 				<default>.*</default>
 			</parameter>
 			<parameter name="transformation" type="text">
 				<label>Transformation</label>
+				<description>Transformation pattern used when processing messages. Multiple transformation can be chained using "∩".</description>
+			</parameter>
+			<parameter name="markAsRead" type="boolean">
+				<label>Mark As Read</label>
+				<description>Mark a processed mail as read and prevent further processing.</description>
+				<default>false</default>
 			</parameter>
 		</config-description>
 	</channel-type>


### PR DESCRIPTION
A new channel-type `content` allows the processing of mail contents. Mails can be filtered by subject and transformed before the item-state is updated.

This has been request in the German Facebook user group.