### PR TITLE
[snmp] add support for UoM

### DIFF
--- a/bundles/org.smarthomej.binding.snmp/README.md
+++ b/bundles/org.smarthomej.binding.snmp/README.md
@@ -132,6 +132,10 @@ In `READ`, `READ_WRITE` or `TRAP` mode they change to either `ON` or `OFF` on th
 The parameters used for defining the values are `onvalue` and `offvalue`.
 The `datatype` parameter is used to convert the configuration strings to the needed values.
 
+`number`-type channels have a `unit` parameter.
+The unit is added to the received value before it is passed to the channel.
+For commands (i.e. sending), the value is first converted to the configured unit. 
+
 | type     | item   | description                     |
 |----------|--------|---------------------------------|
 | number   | Number | a channel with a numeric value  |

--- a/bundles/org.smarthomej.binding.snmp/src/main/java/org/smarthomej/binding/snmp/internal/config/SnmpChannelConfiguration.java
+++ b/bundles/org.smarthomej.binding.snmp/src/main/java/org/smarthomej/binding/snmp/internal/config/SnmpChannelConfiguration.java
@@ -28,6 +28,7 @@ public class SnmpChannelConfiguration {
     public @Nullable String oid;
     public SnmpChannelMode mode = SnmpChannelMode.READ;
     public @Nullable SnmpDatatype datatype;
+    public @Nullable String unit;
 
     public @Nullable String onvalue;
     public @Nullable String offvalue;

--- a/bundles/org.smarthomej.binding.snmp/src/main/java/org/smarthomej/binding/snmp/internal/config/SnmpInternalChannelConfiguration.java
+++ b/bundles/org.smarthomej.binding.snmp/src/main/java/org/smarthomej/binding/snmp/internal/config/SnmpInternalChannelConfiguration.java
@@ -13,6 +13,8 @@
  */
 package org.smarthomej.binding.snmp.internal.config;
 
+import javax.measure.Unit;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.ChannelUID;
@@ -38,10 +40,12 @@ public class SnmpInternalChannelConfiguration {
     public final @Nullable Variable onValue;
     public final @Nullable Variable offValue;
     public final State exceptionValue;
+    public final @Nullable Unit<?> unit;
     public final boolean doNotLogException;
 
     public SnmpInternalChannelConfiguration(ChannelUID channelUID, OID oid, SnmpChannelMode mode, SnmpDatatype datatype,
-            @Nullable Variable onValue, @Nullable Variable offValue, State exceptionValue, boolean doNotLogException) {
+            @Nullable Variable onValue, @Nullable Variable offValue, State exceptionValue, @Nullable Unit<?> unit,
+            boolean doNotLogException) {
         this.channelUID = channelUID;
         this.oid = oid;
         this.mode = mode;
@@ -49,6 +53,7 @@ public class SnmpInternalChannelConfiguration {
         this.onValue = onValue;
         this.offValue = offValue;
         this.exceptionValue = exceptionValue;
+        this.unit = unit;
         this.doNotLogException = doNotLogException;
     }
 }

--- a/bundles/org.smarthomej.binding.snmp/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.snmp/src/main/resources/OH-INF/thing/thing-types.xml
@@ -161,6 +161,10 @@
 				<default>READ</default>
 				<limitToOptions>true</limitToOptions>
 			</parameter>
+			<parameter name="unit" type="text">
+				<label>Unit</label>
+				<description>The unit of this value.</description>
+			</parameter>
 			<parameter name="datatype" type="text">
 				<label>Datatype</label>
 				<description>Content data type</description>

--- a/bundles/org.smarthomej.binding.snmp/src/test/java/org/smarthomej/binding/snmp/internal/AbstractSnmpTargetHandlerTest.java
+++ b/bundles/org.smarthomej.binding.snmp/src/test/java/org/smarthomej/binding/snmp/internal/AbstractSnmpTargetHandlerTest.java
@@ -97,7 +97,12 @@ public abstract class AbstractSnmpTargetHandlerTest extends JavaTest {
 
     protected @Nullable VariableBinding handleCommandNumberStringChannel(ChannelTypeUID channelTypeUID,
             SnmpDatatype datatype, Command command, boolean refresh) throws IOException {
-        setup(channelTypeUID, SnmpChannelMode.WRITE, datatype);
+        return handleCommandNumberStringChannel(channelTypeUID, datatype, null, command, refresh);
+    }
+
+    protected @Nullable VariableBinding handleCommandNumberStringChannel(ChannelTypeUID channelTypeUID,
+            SnmpDatatype datatype, @Nullable String unit, Command command, boolean refresh) throws IOException {
+        setup(channelTypeUID, SnmpChannelMode.WRITE, datatype, null, null, null, unit);
         thingHandler.handleCommand(CHANNEL_UID, command);
 
         if (refresh) {
@@ -178,6 +183,12 @@ public abstract class AbstractSnmpTargetHandlerTest extends JavaTest {
 
     protected void setup(ChannelTypeUID channelTypeUID, SnmpChannelMode channelMode, @Nullable SnmpDatatype datatype,
             @Nullable String onValue, @Nullable String offValue, @Nullable String exceptionValue) {
+        setup(channelTypeUID, channelMode, datatype, onValue, offValue, exceptionValue, null);
+    }
+
+    protected void setup(ChannelTypeUID channelTypeUID, SnmpChannelMode channelMode, @Nullable SnmpDatatype datatype,
+            @Nullable String onValue, @Nullable String offValue, @Nullable String exceptionValue,
+            @Nullable String unit) {
         Map<String, Object> channelConfig = new HashMap<>();
         Map<String, Object> thingConfig = new HashMap<>();
         mocks = MockitoAnnotations.openMocks(this);
@@ -201,6 +212,9 @@ public abstract class AbstractSnmpTargetHandlerTest extends JavaTest {
         }
         if (exceptionValue != null) {
             channelConfig.put("exceptionValue", exceptionValue);
+        }
+        if (unit != null) {
+            channelConfig.put("unit", unit);
         }
         Channel channel = ChannelBuilder.create(CHANNEL_UID, itemType).withType(channelTypeUID)
                 .withConfiguration(new Configuration(channelConfig)).build();

--- a/bundles/org.smarthomej.binding.snmp/src/test/java/org/smarthomej/binding/snmp/internal/SnmpTargetHandlerTest.java
+++ b/bundles/org.smarthomej.binding.snmp/src/test/java/org/smarthomej/binding/snmp/internal/SnmpTargetHandlerTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ThingStatus;
 import org.smarthomej.binding.snmp.internal.types.SnmpChannelMode;
@@ -124,8 +125,20 @@ public class SnmpTargetHandlerTest extends AbstractSnmpTargetHandlerTest {
         assertTrue(variable.getVariable() instanceof OctetString);
         assertEquals("12.4", variable.getVariable().toString());
 
+        variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_NUMBER, SnmpDatatype.FLOAT,
+                "°C", new QuantityType<>("50 °F"), true);
+
+        if (variable == null) {
+            fail("'variable' is null");
+            return;
+        }
+
+        assertEquals(new OID(TEST_OID), variable.getOid());
+        assertTrue(variable.getVariable() instanceof OctetString);
+        assertEquals("10.00", variable.getVariable().toString());
+
         variable = handleCommandNumberStringChannel(SnmpBindingConstants.CHANNEL_TYPE_UID_NUMBER, SnmpDatatype.INT32,
-                new StringType(TEST_STRING), false);
+                null, new StringType(TEST_STRING), false);
         assertNull(variable);
     }
 

--- a/bundles/org.smarthomej.binding.snmp/src/test/java/org/smarthomej/binding/snmp/internal/SwitchChannelTest.java
+++ b/bundles/org.smarthomej.binding.snmp/src/test/java/org/smarthomej/binding/snmp/internal/SwitchChannelTest.java
@@ -47,7 +47,6 @@ import org.snmp4j.smi.VariableBinding;
 public class SwitchChannelTest extends AbstractSnmpTargetHandlerTest {
 
     @Test
-    @SuppressWarnings("null")
     public void testCommandsAreProperlyHandledBySwitchChannel() throws IOException {
         VariableBinding variable;
 


### PR DESCRIPTION
This adds support for using units in the SNMP binding. If configured, the unit is added to the incoming value. Commands send to items are either stripped of their unit (if no unit configured for the channel) or converted to the condifured unit before sending.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>