### PR TITLE
[deconz] fix thing update bug

### DIFF
--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/DeconzBaseThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/DeconzBaseThingHandler.java
@@ -212,6 +212,8 @@ public abstract class DeconzBaseThingHandler extends UpdatingBaseThingHandler im
         Channel channel = ChannelBuilder.create(channelUID).withType(channelTypeUID).withKind(kind).build();
         thingBuilder.withChannel(channel);
 
+        logger.trace("Added '{}' to thing '{}'", channelId, thing.getUID());
+
         return true;
     }
 

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/LightThingHandler.java
@@ -320,13 +320,14 @@ public class LightThingHandler extends DeconzBaseThingHandler {
         boolean thingEdited = false;
 
         LightState lightState = lightMessage.state;
-        if (lightState != null && lightState.effect != null) {
-            thingEdited = thingEdited || checkAndUpdateEffectChannels(thingBuilder, lightMessage);
+        if (lightState != null && lightState.effect != null
+                && checkAndUpdateEffectChannels(thingBuilder, lightMessage)) {
+            thingEdited = true;
         }
 
-        String lastSeen = stateResponse.lastseen;
-        thingEdited = thingEdited || checkLastSeen(thingBuilder, lastSeen);
-
+        if (checkLastSeen(thingBuilder, stateResponse.lastseen)) {
+            thingEdited = true;
+        }
         if (thingEdited) {
             updateThing(thingBuilder.build());
         }

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/SensorBaseThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/SensorBaseThingHandler.java
@@ -125,14 +125,21 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler {
         boolean thingEdited = false;
 
         if (sensorConfig.battery != null) {
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_BATTERY_LEVEL, ChannelKind.STATE);
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_BATTERY_LOW, ChannelKind.STATE);
+            if (createChannel(thingBuilder, CHANNEL_BATTERY_LEVEL, ChannelKind.STATE)) {
+                thingEdited = true;
+            }
+            if (createChannel(thingBuilder, CHANNEL_BATTERY_LOW, ChannelKind.STATE)) {
+                thingEdited = true;
+            }
         }
 
-        thingEdited = thingEdited || createTypeSpecificChannels(thingBuilder, sensorConfig, sensorState);
+        if (createTypeSpecificChannels(thingBuilder, sensorConfig, sensorState)) {
+            thingEdited = true;
+        }
 
-        String lastSeen = sensorMessage.lastseen;
-        thingEdited = thingEdited || checkLastSeen(thingBuilder, lastSeen);
+        if (checkLastSeen(thingBuilder, sensorMessage.lastseen)) {
+            thingEdited = true;
+        }
 
         // if the thing was edited, we update it now
         if (thingEdited) {

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/SensorBaseThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/SensorBaseThingHandler.java
@@ -136,6 +136,7 @@ public abstract class SensorBaseThingHandler extends DeconzBaseThingHandler {
 
         // if the thing was edited, we update it now
         if (thingEdited) {
+            logger.debug("Thing configuration changed, updating thing.");
             updateThing(thingBuilder.build());
         }
         ignoreConfigurationUpdate = false;

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/SensorThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/SensorThingHandler.java
@@ -225,37 +225,37 @@ public class SensorThingHandler extends SensorBaseThingHandler {
         boolean thingEdited = false;
 
         // some Xiaomi sensors
-        if (sensorConfig.temperature != null) {
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_TEMPERATURE, ChannelKind.STATE);
+        if (sensorConfig.temperature != null && createChannel(thingBuilder, CHANNEL_TEMPERATURE, ChannelKind.STATE)) {
+            thingEdited = true;
         }
 
         // ZHAPresence - e.g. IKEA TRÅDFRI motion sensor
-        if (sensorState.dark != null) {
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_DARK, ChannelKind.STATE);
+        if (sensorState.dark != null && createChannel(thingBuilder, CHANNEL_DARK, ChannelKind.STATE)) {
+            thingEdited = true;
         }
 
         // ZHAConsumption - e.g Bitron 902010/25 or Heiman SmartPlug
-        if (sensorState.power != null) {
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_POWER, ChannelKind.STATE);
+        if (sensorState.power != null && createChannel(thingBuilder, CHANNEL_POWER, ChannelKind.STATE)) {
+            thingEdited = true;
         }
 
         // ZHAPower - e.g. Heiman SmartPlug
-        if (sensorState.voltage != null) {
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_VOLTAGE, ChannelKind.STATE);
+        if (sensorState.voltage != null && createChannel(thingBuilder, CHANNEL_VOLTAGE, ChannelKind.STATE)) {
+            thingEdited = true;
         }
-        if (sensorState.current != null) {
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_CURRENT, ChannelKind.STATE);
+        if (sensorState.current != null && createChannel(thingBuilder, CHANNEL_CURRENT, ChannelKind.STATE)) {
+            thingEdited = true;
         }
 
         // IAS Zone sensor - e.g. Heiman HS1MS motion sensor
-        if (sensorState.tampered != null) {
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_TAMPERED, ChannelKind.STATE);
+        if (sensorState.tampered != null && createChannel(thingBuilder, CHANNEL_TAMPERED, ChannelKind.STATE)) {
+            thingEdited = true;
         }
 
         // e.g. Aqara Cube
-        if (sensorState.gesture != null) {
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_GESTURE, ChannelKind.STATE);
-            thingEdited = thingEdited || createChannel(thingBuilder, CHANNEL_GESTUREEVENT, ChannelKind.TRIGGER);
+        if (sensorState.gesture != null && (createChannel(thingBuilder, CHANNEL_GESTURE, ChannelKind.STATE)
+                || createChannel(thingBuilder, CHANNEL_GESTUREEVENT, ChannelKind.TRIGGER))) {
+            thingEdited = true;
         }
 
         return thingEdited;


### PR DESCRIPTION
This is a very nasty bug:

`thingEdited = thingEdited || addChannel` 

was optimized by the compiler in a way that `addChannel` was not called any more when `thingEdited` is already true. The result is that only the first channel is added. On next initialization the next channel is added (because the first is already present and `addChannel` returns false. This results in unnecessary consecutive thing updates.