### PR TITLE
[infrastructure] fix oh-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <maven.compiler.target>${oh.java.version}</maven.compiler.target>
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
-    <ohc.version>3.1.0-SNAPSHOT</ohc.version>
+    <ohc.version>3.1.0</ohc.version>
     <bnd.version>5.3.0</bnd.version>
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.3.0</eea.version>


### PR DESCRIPTION
After the release of openHAB 3.1.0 the core can be fixed and we can finally also release for the new OH core.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>