### PR TITLE
fix versions in bundles

### DIFF
--- a/bundles/org.smarthomej.binding.mail/pom.xml
+++ b/bundles/org.smarthomej.binding.mail/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.smarthomej.addons.bundles</groupId>
       <artifactId>org.smarthomej.commons</artifactId>
-      <version>3.1.3-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.smarthomej.io.repomanager/pom.xml
+++ b/bundles/org.smarthomej.io.repomanager/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>org.smarthomej.io.repomanager</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
 
   <name>SmartHome/J Add-ons :: Bundles :: SmartHome/J Repository Manager</name>
 


### PR DESCRIPTION
The mail bundle did reference a wrong commons version and the repomanager had a not needed version in the pom