### PR TITLE
[knx] fix DPT 3.007 for dimmer channels

### DIFF
--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapper.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapper.java
@@ -322,15 +322,16 @@ public class KNXCoreTypeMapper {
                     DPTXlator3BitControlled translator3BitControlled = (DPTXlator3BitControlled) translator;
                     if (translator3BitControlled.getStepCode() == 0) {
                         LOGGER.debug("convertRawDataToType: KNX DPT_Control_Dimming: break received.");
-                        return UnDefType.UNDEF;
+                        return UnDefType.NULL;
                     }
                     switch (m.group("sub")) {
-                        case "7":
+                        case "007":
                             return translator3BitControlled.getControlBit() ? IncreaseDecreaseType.INCREASE
                                     : IncreaseDecreaseType.DECREASE;
-                        case "8":
+                        case "008":
                             return translator3BitControlled.getControlBit() ? UpDownType.DOWN : UpDownType.UP;
                     }
+                    break;
                 case "18":
                     DPTXlatorSceneControl translatorSceneControl = (DPTXlatorSceneControl) translator;
                     int decimalValue = translatorSceneControl.getSceneNumber();

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/DeviceThingHandler.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/DeviceThingHandler.java
@@ -357,7 +357,7 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
                     }
                 }
             } else {
-                if (value instanceof State) {
+                if (value instanceof State && !(value instanceof UnDefType)) {
                     updateState(knxChannel.getChannelUID(), (State) value);
                 }
             }


### PR DESCRIPTION
`UnDefType.UNDEF` is used to model the KNX command "incremental dimming/stop". In dimmer-control channels this has been properly processed, but in dimmer-channels this was not ignored but posted to the channel, leading to a wrong item state.

[openHAB #6970](https://github.com/openhab/openhab-addons/issues/6970)

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>