### PR TITLE
[deconz] add locked channel for thermostats

### DIFF
--- a/bundles/org.smarthomej.binding.deconz/README.md
+++ b/bundles/org.smarthomej.binding.deconz/README.md
@@ -153,6 +153,7 @@ The sensor devices support some of the following channels:
 | carbonmonoxide  | Switch                   | R           | `ON` = carbon monoxide detected                                                           | carbonmonoxide                                    |
 | color           | Color                    | R           | Color set by remote                                                                       | colorcontrol                                      |
 | windowopen      | Contact                  | R           | `windowopen` status is reported by some thermostats                                       | thermostat                                        |
+| locked          | Switch                   | R/W         | reports/sets the childlock on some thermostats                                            | thermostat                                        |
 
 **NOTE:** Beside other non mandatory channels, the `battery_level` and `battery_low` channels will be added to the Thing during runtime if the sensor is battery-powered.
 The specification of your sensor depends on the deCONZ capabilities.

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/BindingConstants.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/BindingConstants.java
@@ -102,6 +102,7 @@ public class BindingConstants {
     public static final String CHANNEL_CARBONMONOXIDE = "carbonmonoxide";
     public static final String CHANNEL_HEATSETPOINT = "heatsetpoint";
     public static final String CHANNEL_THERMOSTAT_MODE = "mode";
+    public static final String CHANNEL_THERMOSTAT_LOCKED = "locked";
     public static final String CHANNEL_TEMPERATURE_OFFSET = "offset";
     public static final String CHANNEL_VALVE_POSITION = "valve";
     public static final String CHANNEL_WINDOWOPEN = "windowopen";

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/dto/SensorConfig.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/dto/SensorConfig.java
@@ -36,10 +36,12 @@ public class SensorConfig {
     public @Nullable Integer heatsetpoint;
     public @Nullable ThermostatMode mode;
     public @Nullable Integer offset;
+    public @Nullable Boolean locked;
 
     @Override
     public String toString() {
         return "SensorConfig{" + "on=" + on + ", reachable=" + reachable + ", battery=" + battery + ", temperature="
-                + temperature + ", heatsetpoint=" + heatsetpoint + ", mode=" + mode + ", offset=" + offset + "}";
+                + temperature + ", heatsetpoint=" + heatsetpoint + ", mode=" + mode + ", offset=" + offset + ", locked="
+                + locked + "}";
     }
 }

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/dto/ThermostatUpdateConfig.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/dto/ThermostatUpdateConfig.java
@@ -27,4 +27,5 @@ public class ThermostatUpdateConfig {
     public @Nullable Integer heatsetpoint;
     public @Nullable ThermostatMode mode;
     public @Nullable Integer offset;
+    public @Nullable Boolean locked;
 }

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/SensorThermostatThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/SensorThermostatThingHandler.java
@@ -28,6 +28,7 @@ import javax.measure.quantity.Temperature;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
@@ -68,7 +69,7 @@ public class SensorThermostatThingHandler extends SensorBaseThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_THERMOSTAT);
 
     private static final List<String> CONFIG_CHANNELS = Arrays.asList(CHANNEL_BATTERY_LEVEL, CHANNEL_BATTERY_LOW,
-            CHANNEL_HEATSETPOINT, CHANNEL_TEMPERATURE_OFFSET, CHANNEL_THERMOSTAT_MODE);
+            CHANNEL_HEATSETPOINT, CHANNEL_TEMPERATURE_OFFSET, CHANNEL_THERMOSTAT_MODE, CHANNEL_THERMOSTAT_LOCKED);
 
     private final Logger logger = LoggerFactory.getLogger(SensorThermostatThingHandler.class);
 
@@ -85,6 +86,9 @@ public class SensorThermostatThingHandler extends SensorBaseThingHandler {
         }
         ThermostatUpdateConfig newConfig = new ThermostatUpdateConfig();
         switch (channelUID.getId()) {
+            case CHANNEL_THERMOSTAT_LOCKED:
+                newConfig.locked = OnOffType.ON.equals(command);
+                break;
             case CHANNEL_HEATSETPOINT:
                 Integer newHeatsetpoint = getTemperatureFromCommand(command);
                 if (newHeatsetpoint == null) {
@@ -135,6 +139,9 @@ public class SensorThermostatThingHandler extends SensorBaseThingHandler {
         ThermostatMode thermostatMode = newConfig.mode;
         String mode = thermostatMode != null ? thermostatMode.name() : ThermostatMode.UNKNOWN.name();
         switch (channelUID.getId()) {
+            case CHANNEL_THERMOSTAT_LOCKED:
+                updateSwitchChannel(channelUID, newConfig.locked);
+                break;
             case CHANNEL_HEATSETPOINT:
                 updateQuantityTypeChannel(channelUID, newConfig.heatsetpoint, CELSIUS, 1.0 / 100);
                 break;
@@ -169,7 +176,11 @@ public class SensorThermostatThingHandler extends SensorBaseThingHandler {
     @Override
     protected boolean createTypeSpecificChannels(ThingBuilder thingBuilder, SensorConfig sensorConfig,
             SensorState sensorState) {
-        return false;
+        boolean thingEdited = false;
+        if (sensorConfig.locked != null && createChannel(thingBuilder, CHANNEL_THERMOSTAT_LOCKED, ChannelKind.STATE)) {
+            thingEdited = true;
+        }
+        return thingEdited;
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.deconz/src/main/resources/OH-INF/thing/sensor-thing-types.xml
+++ b/bundles/org.smarthomej.binding.deconz/src/main/resources/OH-INF/thing/sensor-thing-types.xml
@@ -525,6 +525,7 @@
 		<item-type>Switch</item-type>
 		<label>Locked</label>
 		<description>Status of this thermostat's childlock.</description>
+		<category>Lock</category>
 	</channel-type>
 	<channel-type id="heatsetpoint">
 		<item-type>Number:Temperature</item-type>

--- a/bundles/org.smarthomej.binding.deconz/src/main/resources/OH-INF/thing/sensor-thing-types.xml
+++ b/bundles/org.smarthomej.binding.deconz/src/main/resources/OH-INF/thing/sensor-thing-types.xml
@@ -521,6 +521,11 @@
 		<config-description-ref uri="thing-type:deconz:sensor"/>
 	</thing-type>
 
+	<channel-type id="locked">
+		<item-type>Switch</item-type>
+		<label>Locked</label>
+		<description>Status of this thermostat's childlock.</description>
+	</channel-type>
 	<channel-type id="heatsetpoint">
 		<item-type>Number:Temperature</item-type>
 		<label>Target temperature</label>


### PR DESCRIPTION
Some thermostats provide a keylock to protect the settings. The `locked` channel is added when available and is readable and writable.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>