### PR TITLE
[influxdb] Fix queries for migrated databases

### DIFF
--- a/bundles/org.smarthomej.persistence.influxdb/src/main/java/org/smarthomej/persistence/influxdb/internal/InfluxDBConstants.java
+++ b/bundles/org.smarthomej.persistence.influxdb/src/main/java/org/smarthomej/persistence/influxdb/internal/InfluxDBConstants.java
@@ -29,6 +29,7 @@ public class InfluxDBConstants {
     public static final String COLUMN_TIME_NAME_V2 = "_time";
 
     public static final String FIELD_VALUE_NAME = "value";
+    public static final String FIELD_MEASUREMENT_NAME = "_measurement";
     public static final String TAG_ITEM_NAME = "item";
     public static final String TAG_CATEGORY_NAME = "category";
     public static final String TAG_TYPE_NAME = "type";

--- a/bundles/org.smarthomej.persistence.influxdb/src/main/java/org/smarthomej/persistence/influxdb/internal/influx2/InfluxDB2FilterCriteriaQueryCreatorImpl.java
+++ b/bundles/org.smarthomej.persistence.influxdb/src/main/java/org/smarthomej/persistence/influxdb/internal/influx2/InfluxDB2FilterCriteriaQueryCreatorImpl.java
@@ -16,7 +16,10 @@ package org.smarthomej.persistence.influxdb.internal.influx2;
 import static com.influxdb.query.dsl.functions.restriction.Restrictions.measurement;
 import static com.influxdb.query.dsl.functions.restriction.Restrictions.tag;
 import static org.smarthomej.persistence.influxdb.internal.InfluxDBConstants.COLUMN_TIME_NAME_V2;
+import static org.smarthomej.persistence.influxdb.internal.InfluxDBConstants.COLUMN_VALUE_NAME_V2;
+import static org.smarthomej.persistence.influxdb.internal.InfluxDBConstants.FIELD_MEASUREMENT_NAME;
 import static org.smarthomej.persistence.influxdb.internal.InfluxDBConstants.FIELD_VALUE_NAME;
+import static org.smarthomej.persistence.influxdb.internal.InfluxDBConstants.TAG_ITEM_NAME;
 import static org.smarthomej.persistence.influxdb.internal.InfluxDBStateConvertUtils.stateToObject;
 
 import java.time.temporal.ChronoUnit;
@@ -55,12 +58,12 @@ public class InfluxDB2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQu
 
         RangeFlux range = flux.range();
         if (criteria.getBeginDate() != null) {
-            range = range.withStart(criteria.getBeginDate().toInstant());
+            range.withStart(criteria.getBeginDate().toInstant());
         } else {
             range = flux.range(-100L, ChronoUnit.YEARS); // Flux needs a mandatory start range
         }
         if (criteria.getEndDate() != null) {
-            range = range.withStop(criteria.getEndDate().toInstant());
+            range.withStop(criteria.getEndDate().toInstant());
         }
         flux = range;
 
@@ -69,7 +72,11 @@ public class InfluxDB2FilterCriteriaQueryCreatorImpl implements FilterCriteriaQu
             String measurementName = getMeasurementName(itemName);
             flux = flux.filter(measurement().equal(measurementName));
             if (!measurementName.equals(itemName)) {
-                flux = flux.filter(tag("item").equal(itemName));
+                flux = flux.filter(tag(TAG_ITEM_NAME).equal(itemName));
+                flux = flux.keep(new String[] { FIELD_MEASUREMENT_NAME, COLUMN_TIME_NAME_V2, COLUMN_VALUE_NAME_V2,
+                        TAG_ITEM_NAME });
+            } else {
+                flux = flux.keep(new String[] { FIELD_MEASUREMENT_NAME, COLUMN_TIME_NAME_V2, COLUMN_VALUE_NAME_V2 });
             }
         }
 

--- a/bundles/org.smarthomej.persistence.influxdb/src/test/java/org/smarthomej/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
+++ b/bundles/org.smarthomej.persistence.influxdb/src/test/java/org/smarthomej/persistence/influxdb/internal/InfluxFilterCriteriaQueryCreatorImplTest.java
@@ -81,8 +81,10 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem;"));
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")"));
+        assertThat(queryV2,
+                equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
+                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])"));
     }
 
     @Test
@@ -114,7 +116,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         String expectedQueryV2 = String.format(
                 "from(bucket:\"origin\")\n\t" + "|> range(start:%s, stop:%s)\n\t"
-                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")",
+                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])",
                 INFLUX2_DATE_FORMATTER.format(now.toInstant()), INFLUX2_DATE_FORMATTER.format(tomorrow.toInstant()));
         assertThat(queryV2, equalTo(expectedQueryV2));
     }
@@ -132,6 +135,7 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
                         + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t"
                         + "|> filter(fn: (r) => (r[\"_field\"] == \"value\" and r[\"_value\"] <= 90))"));
     }
 
@@ -146,7 +150,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
 
         String queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
         assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t" + "|> limit(n:10, offset:20)"));
+                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t" + "|> limit(n:10, offset:20)"));
     }
 
     @Test
@@ -161,6 +166,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
                         + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])\n\t"
+
                         + "|> sort(desc:false, columns:[\"_time\"])"));
     }
 
@@ -191,8 +198,8 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV2,
                 equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
                         + "|> filter(fn: (r) => r[\"_measurement\"] == \"measurementName\")\n\t"
-                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")"));
-
+                        + "|> filter(fn: (r) => r[\"item\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\", \"item\"])"));
         when(metadataRegistry.get(metadataKey))
                 .thenReturn(new Metadata(metadataKey, "", Map.of("key1", "val1", "key2", "val2")));
 
@@ -200,7 +207,9 @@ public class InfluxFilterCriteriaQueryCreatorImplTest {
         assertThat(queryV1, equalTo("SELECT \"value\"::field,\"item\"::tag FROM origin.sampleItem;"));
 
         queryV2 = instanceV2.createQuery(criteria, RETENTION_POLICY);
-        assertThat(queryV2, equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
-                + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")"));
+        assertThat(queryV2,
+                equalTo("from(bucket:\"origin\")\n\t" + "|> range(start:-100y)\n\t"
+                        + "|> filter(fn: (r) => r[\"_measurement\"] == \"sampleItem\")\n\t"
+                        + "|> keep(columns:[\"_measurement\", \"_time\", \"_value\"])"));
     }
 }


### PR DESCRIPTION
Fixes bug in queries with InfluxDB 2.0 that had data migrated from InfluxDB 1.0 with old versions of the addon that didn't put item tag name.

Originally-by: Joan Pujol <joanpujol@gmail.com>
Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>

Original-PR: https://github.com/openhab/openhab-addons/pull/10937