### PR TITLE
[deconz] improve logging

### DIFF
--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/netutils/WebSocketConnection.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/netutils/WebSocketConnection.java
@@ -93,7 +93,11 @@ public class WebSocketConnection {
             client.connect(this, destUri).get();
         } catch (Exception e) {
             String reason = "Error while connecting: " + e.getMessage();
-            logger.warn("{}: {}", socketName, reason);
+            if (e.getMessage() == null) {
+                logger.warn("{}: {}", socketName, reason, e);
+            } else {
+                logger.warn("{}: {}", socketName, reason);
+            }
             connectionListener.webSocketConnectionLost(reason);
         }
     }


### PR DESCRIPTION
Connections issues that do not contain a message are hard to fix. This adds the exception stack trace to the log message if no message is present to get a hint what went wrong.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>