### PR TITLE
[androiddebugbridge] start intent channel

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/pom.xml
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/pom.xml
@@ -16,6 +16,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.smarthomej.addons.bundles</groupId>
+      <artifactId>org.smarthomej.commons</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.tananaev</groupId>
       <artifactId>adblib</artifactId>
       <version>1.3</version>

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/feature/feature.xml
@@ -4,6 +4,7 @@
 
 	<feature name="smarthomej-binding-androiddebugbridge" description="Android Debug Bridge Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<bundle dependency="true">mvn:org.smarthomej.addons.bundles/org.smarthomej.commons/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.androiddebugbridge/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeBindingConstants.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeBindingConstants.java
@@ -44,6 +44,7 @@ public class AndroidDebugBridgeBindingConstants {
     public static final String STOP_PACKAGE_CHANNEL = "stop-package";
     public static final String STOP_CURRENT_PACKAGE_CHANNEL = "stop-current-package";
     public static final String OPEN_URL_CHANNEL = "open-url";
+    public static final String START_INTENT_CHANNEL = "start-intent";
     public static final String CURRENT_PACKAGE_CHANNEL = "current-package";
     public static final String SHUTDOWN_CHANNEL = "shutdown";
     public static final String AWAKE_STATE_CHANNEL = "awake-state";

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -68,7 +68,7 @@ public class AndroidDebugBridgeDevice {
     private static final Pattern PACKAGE_NAME_PATTERN = Pattern
             .compile("^([A-Za-z]{1}[A-Za-z\\d_\\/]*\\.)+[A-Za-z][A-Za-z\\d_]*$");
     private static final Pattern INTENT_STRING_PATTERN = Pattern
-            .compile("intent://(?:[\\w\\./]*?)#Intent;(?:[\\w\\.]+=[\\w\\.]+;)+end");
+            .compile("intent://(?:[\\w\\./\\-_]*?)#Intent;(?:[\\w\\.\\-_]+=[\\w\\.\\-_]+;)+end");
 
     private static @Nullable AdbCrypto adbCrypto;
 

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -161,6 +161,11 @@ public class AndroidDebugBridgeDevice {
         runAdbShell("am", "start", "-a", "android.intent.action.VIEW", "-d", url);
     }
 
+    public void startIntent(String intent)
+            throws AndroidDebugBridgeDeviceException, InterruptedException, TimeoutException, ExecutionException {
+        runAdbShell("am", "start", "\"" + intent + "\"");
+    }
+
     public String getCurrentPackage() throws AndroidDebugBridgeDeviceException, InterruptedException,
             AndroidDebugBridgeDeviceReadException, TimeoutException, ExecutionException {
         String result = runAdbShell("dumpsys", "window", "windows", "|", "grep", "mFocusedApp");

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -67,6 +67,8 @@ public class AndroidDebugBridgeDevice {
     private static final Pattern TAP_EVENT_PATTERN = Pattern.compile("(?<x>\\d+),(?<y>\\d+)");
     private static final Pattern PACKAGE_NAME_PATTERN = Pattern
             .compile("^([A-Za-z]{1}[A-Za-z\\d_\\/]*\\.)+[A-Za-z][A-Za-z\\d_]*$");
+    private static final Pattern INTENT_STRING_PATTERN = Pattern
+            .compile("intent://(?:[\\w\\./]*?)#Intent;(?:[\\w\\.]+=[\\w\\.]+;)+end");
 
     private static @Nullable AdbCrypto adbCrypto;
 
@@ -161,9 +163,13 @@ public class AndroidDebugBridgeDevice {
         runAdbShell("am", "start", "-a", "android.intent.action.VIEW", "-d", url);
     }
 
-    public void startIntent(String intent)
+    public void startIntent(String intentString)
             throws AndroidDebugBridgeDeviceException, InterruptedException, TimeoutException, ExecutionException {
-        runAdbShell("am", "start", "\"" + intent + "\"");
+        if (!INTENT_STRING_PATTERN.matcher(intentString).matches()) {
+            LOGGER.warn("{} is not a valid intent string", intentString);
+            return;
+        }
+        runAdbShell("am", "start", "\"" + intentString + "\"");
     }
 
     public String getCurrentPackage() throws AndroidDebugBridgeDeviceException, InterruptedException,

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -156,6 +156,11 @@ public class AndroidDebugBridgeHandler extends BaseThingHandler {
                 handleCommandInternal(new ChannelUID(this.thing.getUID(), CURRENT_PACKAGE_CHANNEL),
                         RefreshType.REFRESH);
                 break;
+            case START_INTENT_CHANNEL:
+                adbConnection.startIntent(command.toFullString());
+                handleCommandInternal(new ChannelUID(this.thing.getUID(), CURRENT_PACKAGE_CHANNEL),
+                        RefreshType.REFRESH);
+                break;
             case CURRENT_PACKAGE_CHANNEL:
                 if (command instanceof RefreshType) {
                     String currentPackage = adbConnection.getCurrentPackage();

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -38,13 +38,13 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
-import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.CommandOption;
 import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBridgeDevice.VolumeInfo;
+import org.smarthomej.commons.UpdatingBaseThingHandler;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -56,7 +56,7 @@ import com.google.gson.JsonSyntaxException;
  * @author Miguel Álvarez - Initial contribution
  */
 @NonNullByDefault
-public class AndroidDebugBridgeHandler extends BaseThingHandler {
+public class AndroidDebugBridgeHandler extends UpdatingBaseThingHandler {
 
     public static final String KEY_EVENT_PLAY = "126";
     public static final String KEY_EVENT_PAUSE = "127";

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
@@ -25,6 +25,9 @@
 			<channel id="hdmi-state" typeId="hdmi-state-channel"/>
 			<channel id="shutdown" typeId="shutdown-channel"/>
 		</channels>
+		<properties>
+			<property name="thingTypeVersion">1</property>
+		</properties>
 		<representation-property>serial</representation-property>
 		<config-description>
 			<parameter name="ip" type="text" required="true">

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/resources/OH-INF/thing/thing-types.xml
@@ -17,6 +17,7 @@
 			<channel id="stop-package" typeId="stop-package-channel"/>
 			<channel id="stop-current-package" typeId="stop-current-package-channel"/>
 			<channel id="open-url" typeId="open-url-channel"/>
+			<channel id="start-intent" typeId="start-intent-channel"/>
 			<channel id="current-package" typeId="current-package-channel"/>
 			<channel id="wake-lock" typeId="wake-lock-channel"/>
 			<channel id="screen-state" typeId="screen-state-channel"/>
@@ -387,6 +388,12 @@
 		<item-type>String</item-type>
 		<label>Open URL</label>
 		<description>Open URL</description>
+	</channel-type>
+
+	<channel-type id="start-intent-channel">
+		<item-type>String</item-type>
+		<label>Start Intent</label>
+		<description>Start Intent</description>
 	</channel-type>
 
 	<channel-type id="current-package-channel">

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/resources/update/android.update
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/resources/update/android.update
@@ -1,0 +1,1 @@
+1;ADD_CHANNEL;start-intent,String,androiddebugbridge:start-intent-channel


### PR DESCRIPTION
added: start intent channel

adb shell 'am start "intent:#Intent;scheme=customapp;package=com.comp.pac;end"'

Source: https://stackoverflow.com/questions/21034168/android-start-an-activity-from-command-line-using-intent-uri

Signed-off-by: Tom Blum <trinitus01@googlemail.com>