### PR TITLE
[commons] fix thing handler missing

### DIFF
--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/UpdatingBaseBridgeHandler.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/UpdatingBaseBridgeHandler.java
@@ -47,7 +47,7 @@ public abstract class UpdatingBaseBridgeHandler extends BaseBridgeHandler {
     public void setCallback(@Nullable ThingHandlerCallback thingHandlerCallback) {
         super.setCallback(thingHandlerCallback);
         if (thingHandlerCallback != null && thingUpdater.thingNeedsUpdate()) {
-            thingUpdater.update(editThing(), thingHandlerCallback, this::isInitialized, this::updateThing);
+            thingUpdater.update(this::editThing, thingHandlerCallback, this::isInitialized, this::updateThing);
         }
     }
 }

--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/UpdatingBaseBridgeHandler.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/UpdatingBaseBridgeHandler.java
@@ -47,7 +47,7 @@ public abstract class UpdatingBaseBridgeHandler extends BaseBridgeHandler {
     public void setCallback(@Nullable ThingHandlerCallback thingHandlerCallback) {
         super.setCallback(thingHandlerCallback);
         if (thingHandlerCallback != null && thingUpdater.thingNeedsUpdate()) {
-            updateThing(thingUpdater.update(editThing(), thingHandlerCallback).build());
+            thingUpdater.update(editThing(), thingHandlerCallback, this::isInitialized, this::updateThing);
         }
     }
 }

--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/UpdatingBaseThingHandler.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/UpdatingBaseThingHandler.java
@@ -46,7 +46,7 @@ public abstract class UpdatingBaseThingHandler extends BaseThingHandler {
     public void setCallback(@Nullable ThingHandlerCallback thingHandlerCallback) {
         super.setCallback(thingHandlerCallback);
         if (thingHandlerCallback != null && thingUpdater.thingNeedsUpdate()) {
-            updateThing(thingUpdater.update(editThing(), thingHandlerCallback).build());
+            thingUpdater.update(editThing(), thingHandlerCallback, this::isInitialized, this::updateThing);
         }
     }
 }

--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/UpdatingBaseThingHandler.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/UpdatingBaseThingHandler.java
@@ -46,7 +46,7 @@ public abstract class UpdatingBaseThingHandler extends BaseThingHandler {
     public void setCallback(@Nullable ThingHandlerCallback thingHandlerCallback) {
         super.setCallback(thingHandlerCallback);
         if (thingHandlerCallback != null && thingUpdater.thingNeedsUpdate()) {
-            thingUpdater.update(editThing(), thingHandlerCallback, this::isInitialized, this::updateThing);
+            thingUpdater.update(this::editThing, thingHandlerCallback, this::isInitialized, this::updateThing);
         }
     }
 }

--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/impl/ThingUpdater.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/impl/ThingUpdater.java
@@ -22,10 +22,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Scanner;
 import java.util.TreeMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
@@ -50,6 +55,8 @@ public class ThingUpdater {
     private final TreeMap<Integer, List<UpdateInstruction>> updateInstructions = new TreeMap<>();
     private final ThingUID thingUid;
     private int currentThingTypeVersion;
+    private final ScheduledExecutorService scheduler = ThreadPoolManager
+            .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
 
     public ThingUpdater(Thing thing, Class<?> clazz) {
         currentThingTypeVersion = Integer
@@ -105,14 +112,20 @@ public class ThingUpdater {
         return !updateInstructions.isEmpty();
     }
 
-    public ThingBuilder update(ThingBuilder thingBuilder, ThingHandlerCallback callback) {
+    public void update(ThingBuilder thingBuilder, ThingHandlerCallback callback, Supplier<Boolean> isInitialized,
+            Consumer<Thing> update) {
+        if (!isInitialized.get()) {
+            logger.trace("Thing {} is not yet initialized, deferring update for 500ms.", thingUid);
+            scheduler.schedule(() -> update(thingBuilder, callback, isInitialized, update), 500, TimeUnit.MILLISECONDS);
+            return;
+        }
         updateInstructions.forEach((targetThingTypeVersion, updateInstruction) -> {
             logger.info("Updating {} from version {} to {}", thingUid, currentThingTypeVersion, targetThingTypeVersion);
             updateInstruction.forEach(instruction -> processUpdateInstruction(instruction, thingBuilder, callback));
             currentThingTypeVersion = targetThingTypeVersion;
         });
         thingBuilder.withProperties(Map.of(PROPERTY_THING_TYPE_VERSION, String.valueOf(updateInstructions.lastKey())));
-        return thingBuilder;
+        update.accept(thingBuilder.build());
     }
 
     private void processUpdateInstruction(UpdateInstruction instruction, ThingBuilder thingBuilder,

--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/impl/ThingUpdater.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/impl/ThingUpdater.java
@@ -112,13 +112,15 @@ public class ThingUpdater {
         return !updateInstructions.isEmpty();
     }
 
-    public void update(ThingBuilder thingBuilder, ThingHandlerCallback callback, Supplier<Boolean> isInitialized,
-            Consumer<Thing> update) {
+    public void update(Supplier<ThingBuilder> thingBuilderSupplier, ThingHandlerCallback callback,
+            Supplier<Boolean> isInitialized, Consumer<Thing> update) {
         if (!isInitialized.get()) {
             logger.trace("Thing {} is not yet initialized, deferring update for 500ms.", thingUid);
-            scheduler.schedule(() -> update(thingBuilder, callback, isInitialized, update), 500, TimeUnit.MILLISECONDS);
+            scheduler.schedule(() -> update(thingBuilderSupplier, callback, isInitialized, update), 500,
+                    TimeUnit.MILLISECONDS);
             return;
         }
+        ThingBuilder thingBuilder = thingBuilderSupplier.get();
         updateInstructions.forEach((targetThingTypeVersion, updateInstruction) -> {
             logger.info("Updating {} from version {} to {}", thingUid, currentThingTypeVersion, targetThingTypeVersion);
             updateInstruction.forEach(instruction -> processUpdateInstruction(instruction, thingBuilder, callback));

--- a/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/UpdatingBaseBridgeHandlerTest.java
+++ b/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/UpdatingBaseBridgeHandlerTest.java
@@ -14,6 +14,7 @@ package org.smarthomej.commons;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.smarthomej.commons.UpdatingBaseThingHandler.PROPERTY_THING_TYPE_VERSION;
 
 import java.util.Map;
@@ -88,7 +89,8 @@ public class UpdatingBaseBridgeHandlerTest {
         TestBridgeHandler testBridgeHandler = new TestBridgeHandler(bridge);
         testBridgeHandler.setCallback(callback);
 
-        Mockito.verify(callback).thingUpdated(thingCaptor.capture());
+        Mockito.verify(callback, timeout(2000)).thingUpdated(thingCaptor.capture());
+        Assertions.assertEquals(2, testBridgeHandler.initializeCounter);
         Bridge newBridge = thingCaptor.getValue();
 
         Channel newChannel = newBridge.getChannel("testChannel1");
@@ -123,7 +125,8 @@ public class UpdatingBaseBridgeHandlerTest {
         TestBridgeHandler testBridgeHandler = new TestBridgeHandler(bridge);
         testBridgeHandler.setCallback(callback);
 
-        Mockito.verify(callback).thingUpdated(thingCaptor.capture());
+        Mockito.verify(callback, timeout(2000)).thingUpdated(thingCaptor.capture());
+        Assertions.assertEquals(2, testBridgeHandler.initializeCounter);
         Bridge newBridge = thingCaptor.getValue();
 
         Assertions.assertEquals(0, newBridge.getChannels().size());
@@ -140,7 +143,8 @@ public class UpdatingBaseBridgeHandlerTest {
         TestBridgeHandler testBridgeHandler = new TestBridgeHandler(bridge);
         testBridgeHandler.setCallback(callback);
 
-        Mockito.verify(callback).thingUpdated(thingCaptor.capture());
+        Mockito.verify(callback, timeout(2000)).thingUpdated(thingCaptor.capture());
+        Assertions.assertEquals(2, testBridgeHandler.initializeCounter);
         Bridge newBridge = thingCaptor.getValue();
 
         Channel newChannel = newBridge.getChannel("testChannel");
@@ -163,7 +167,8 @@ public class UpdatingBaseBridgeHandlerTest {
         TestBridgeHandler testBridgeHandler = new TestBridgeHandler(bridge);
         testBridgeHandler.setCallback(callback);
 
-        Mockito.verify(callback).thingUpdated(thingCaptor.capture());
+        Mockito.verify(callback, timeout(2000)).thingUpdated(thingCaptor.capture());
+        Assertions.assertEquals(2, testBridgeHandler.initializeCounter);
         Bridge newBridge = thingCaptor.getValue();
 
         // added channel
@@ -203,6 +208,13 @@ public class UpdatingBaseBridgeHandlerTest {
     private static class TestBridgeHandler extends UpdatingBaseBridgeHandler {
         public TestBridgeHandler(Bridge bridge) {
             super(bridge);
+        }
+
+        private int initializeCounter = 0;
+
+        @Override
+        protected boolean isInitialized() {
+            return ++initializeCounter > 1;
         }
 
         @Override

--- a/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/UpdatingBaseThingHandlerTest.java
+++ b/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/UpdatingBaseThingHandlerTest.java
@@ -14,6 +14,7 @@ package org.smarthomej.commons;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.smarthomej.commons.UpdatingBaseThingHandler.PROPERTY_THING_TYPE_VERSION;
 
 import java.util.Map;
@@ -88,7 +89,8 @@ public class UpdatingBaseThingHandlerTest {
         TestThingHandler testThingHandler = new TestThingHandler(thing);
         testThingHandler.setCallback(callback);
 
-        Mockito.verify(callback).thingUpdated(thingCaptor.capture());
+        Mockito.verify(callback, timeout(2000)).thingUpdated(thingCaptor.capture());
+        Assertions.assertEquals(2, testThingHandler.initializeCounter);
         Thing newThing = thingCaptor.getValue();
 
         Channel newChannel = newThing.getChannel("testChannel1");
@@ -124,7 +126,8 @@ public class UpdatingBaseThingHandlerTest {
         TestThingHandler testThingHandler = new TestThingHandler(thing);
         testThingHandler.setCallback(callback);
 
-        Mockito.verify(callback).thingUpdated(thingCaptor.capture());
+        Mockito.verify(callback, timeout(2000)).thingUpdated(thingCaptor.capture());
+        Assertions.assertEquals(2, testThingHandler.initializeCounter);
         Thing newThing = thingCaptor.getValue();
 
         Assertions.assertEquals(0, newThing.getChannels().size());
@@ -141,7 +144,8 @@ public class UpdatingBaseThingHandlerTest {
         TestThingHandler testThingHandler = new TestThingHandler(thing);
         testThingHandler.setCallback(callback);
 
-        Mockito.verify(callback).thingUpdated(thingCaptor.capture());
+        Mockito.verify(callback, timeout(2000)).thingUpdated(thingCaptor.capture());
+        Assertions.assertEquals(2, testThingHandler.initializeCounter);
         Thing newThing = thingCaptor.getValue();
 
         Channel newChannel = newThing.getChannel("testChannel");
@@ -164,7 +168,8 @@ public class UpdatingBaseThingHandlerTest {
         TestThingHandler testThingHandler = new TestThingHandler(thing);
         testThingHandler.setCallback(callback);
 
-        Mockito.verify(callback).thingUpdated(thingCaptor.capture());
+        Mockito.verify(callback, timeout(2000)).thingUpdated(thingCaptor.capture());
+        Assertions.assertEquals(2, testThingHandler.initializeCounter);
         Thing newThing = thingCaptor.getValue();
 
         // added channel
@@ -204,6 +209,13 @@ public class UpdatingBaseThingHandlerTest {
     private static class TestThingHandler extends UpdatingBaseThingHandler {
         public TestThingHandler(Thing thing) {
             super(thing);
+        }
+
+        private int initializeCounter = 0;
+
+        @Override
+        protected boolean isInitialized() {
+            return ++initializeCounter > 1;
         }
 
         @Override


### PR DESCRIPTION
This fixes an issue during updating the thing structure. In some cases the thing handler was not properly assigned to the thing immediately after the update, resulting in problems when editing the thing configuration.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>