### PR TITLE
[commons] add a fixed version of the AbstractWatchService

### DIFF
--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/service/AbstractWatchService.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/service/AbstractWatchService.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.commons.service;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Base class for OSGI services that access to file system by Java WatchService.
+ *
+ * See the WatchService <a href="http://docs.oracle.com/javase/7/docs/api/java/nio/file/WatchService.html">java docs</a>
+ * for more details
+ *
+ * @author Fabio Marini - Initial contribution
+ * @author Dimitar Ivanov - added javadoc; introduced WatchKey to directory mapping for the queue reader
+ * @author Ana Dimova - reduce to a single watch thread for all class instances of {@link AbstractWatchService}
+ * @author Jan N. Klug - add null annotations
+ */
+@NonNullByDefault
+public abstract class AbstractWatchService {
+    protected @Nullable String pathToWatch;
+
+    protected AbstractWatchService(String pathToWatch) {
+        this.pathToWatch = pathToWatch;
+    }
+
+    /**
+     * The queue reader
+     */
+    protected WatchQueueReader watchQueueReader = WatchQueueReader.getInstance();
+
+    /**
+     * Method to call on service activation
+     */
+    public void activate() {
+        Path pathToWatch = getSourcePath();
+        if (pathToWatch != null) {
+            watchQueueReader.customizeWatchQueueReader(this, pathToWatch, watchSubDirectories());
+        }
+    }
+
+    /**
+     * Method to call on service deactivation
+     */
+    @SuppressWarnings("unused")
+    public void deactivate() {
+        WatchQueueReader watchQueueReader = this.watchQueueReader;
+        watchQueueReader.stopWatchService(this);
+    }
+
+    /**
+     * @return the path to be watched as a {@link String}. The returned path should be applicable for creating a
+     *         {@link Path} with the {@link Paths#get(String, String...)} method.
+     */
+    public @Nullable Path getSourcePath() {
+        String pathToWatch = this.pathToWatch;
+        return pathToWatch == null || pathToWatch.isBlank() ? null : Paths.get(pathToWatch);
+    }
+
+    /**
+     * Determines whether the subdirectories of the source path (determined by the {@link #getSourcePath()}) will be
+     * watched or not.
+     *
+     * @return <code>true</code> if the subdirectories will be watched and <code>false</code> if only the source path
+     *         (determined by the {@link #getSourcePath()}) will be watched
+     */
+    protected abstract boolean watchSubDirectories();
+
+    /**
+     * Provides the {@link WatchKey}s for the registration of the directory, which will be registered in the watch
+     * service.
+     *
+     * @param directory the directory, which will be registered in the watch service
+     * @return The array of {@link WatchKey}s for the registration or <code>null</code> if no registration has been
+     *         done.
+     */
+    protected abstract Kind<?> @Nullable [] getWatchEventKinds(Path directory);
+
+    /**
+     * Processes the given watch event. Note that the kind and the number of the events for the watched directory is a
+     * platform dependent (see the "Platform dependencies" sections of {@link WatchService}).
+     *
+     * @param event the watch event to be handled
+     * @param kind the event's kind
+     * @param path the path of the event (resolved to the {@link #pathToWatch})
+     */
+    protected abstract void processWatchEvent(WatchEvent<?> event, Kind<?> kind, Path path);
+}

--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/service/WatchQueueReader.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/service/WatchQueueReader.java
@@ -1,0 +1,487 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.commons.service;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.ThreadPoolManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for watch queue readers
+ *
+ * @author Fabio Marini - Initial contribution
+ * @author Dimitar Ivanov - use relative path in watch events. Added option to watch directory events or not
+ * @author Ana Dimova - reduce to a single watch thread for all class instances of {@link AbstractWatchService}
+ * @author Jan N. Klug - allow multiple listeners for the same directory and add null annotations
+ */
+@NonNullByDefault
+public class WatchQueueReader implements Runnable {
+    private static final String THREAD_POOL_NAME = "file-processing";
+    private static final int PROCESSING_DELAY = 1000; // ms
+
+    protected final Logger logger = LoggerFactory.getLogger(WatchQueueReader.class);
+    private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(THREAD_POOL_NAME);
+
+    protected @Nullable WatchService watchService;
+
+    private final Map<WatchKey, Path> registeredKeys = new HashMap<>();
+    private final Map<WatchKey, Set<AbstractWatchService>> keyToService = new HashMap<>();
+    private final Map<AbstractWatchService, Map<Path, byte[]>> hashes = new HashMap<>();
+    private final List<Notification> notifications = new CopyOnWriteArrayList<>();
+
+    private @Nullable Thread qr;
+
+    private static final WatchQueueReader INSTANCE = new WatchQueueReader();
+
+    /**
+     * Perform a simple cast of given event to WatchEvent
+     *
+     * @param event the event to cast
+     * @return the casted event
+     */
+    @SuppressWarnings("unchecked")
+    static <T> WatchEvent<T> cast(WatchEvent<?> event) {
+        return (WatchEvent<T>) event;
+    }
+
+    public static WatchQueueReader getInstance() {
+        return INSTANCE;
+    }
+
+    private WatchQueueReader() {
+        // prevent instantiation
+    }
+
+    // used for testing to check if properly terminated
+    @Nullable
+    WatchService getWatchService() {
+        return watchService;
+    }
+
+    /**
+     * Customize the queue reader to process the watch events for the given directory, provided by the watch service
+     *
+     * @param watchService the watch service, requesting the watch events for the watched directory
+     * @param toWatch the directory being watched by the watch service
+     * @param watchSubDirectories a boolean flag that specifies if the child directories of the registered directory
+     *            will being watched by the watch service
+     */
+    protected void customizeWatchQueueReader(AbstractWatchService watchService, Path toWatch,
+            boolean watchSubDirectories) {
+        try {
+            if (watchSubDirectories) {
+                // walk through all folders and follow symlinks
+                registerWithSubDirectories(watchService, toWatch);
+            } else {
+                registerDirectoryInternal(watchService, watchService.getWatchEventKinds(toWatch), toWatch);
+            }
+        } catch (NoSuchFileException e) {
+            logger.debug("Not watching folder '{}' as it does not exist.", toWatch);
+        } catch (IOException e) {
+            logger.warn("Cannot customize folder watcher for folder '{}'", toWatch, e);
+        }
+    }
+
+    private void registerWithSubDirectories(AbstractWatchService watchService, Path toWatch) throws IOException {
+        Files.walkFileTree(toWatch, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult preVisitDirectory(@Nullable Path subDir,
+                            @Nullable BasicFileAttributes attrs) {
+                        if (subDir != null) {
+                            Kind<?>[] kinds = watchService.getWatchEventKinds(subDir);
+                            registerDirectoryInternal(watchService, kinds, subDir);
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult visitFileFailed(@Nullable Path file, @Nullable IOException exc) {
+                        if (exc instanceof AccessDeniedException) {
+                            logger.warn("Access to folder '{}' was denied, therefore skipping it.",
+                                    file != null ? file.toAbsolutePath() : null);
+                        }
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                });
+    }
+
+    private synchronized void registerDirectoryInternal(AbstractWatchService service, Kind<?> @Nullable [] kinds,
+            Path directory) {
+        WatchService watchService = this.watchService;
+        if (watchService == null) {
+            try {
+                watchService = FileSystems.getDefault().newWatchService();
+                this.watchService = watchService;
+                Thread qr = new Thread(this, "SmartHome/J Dir Watcher");
+                this.qr = qr;
+                qr.start();
+            } catch (IOException e) {
+                logger.debug("The directory '{}' was not registered in the watch service", directory, e);
+                return;
+            }
+        }
+        WatchKey registrationKey = null;
+        if (kinds == null) {
+            return;
+        }
+        try {
+            registrationKey = directory.register(watchService, kinds);
+        } catch (IOException e) {
+            logger.debug("The directory '{}' was not registered in the watch service: {}", directory, e.getMessage());
+        }
+        if (registrationKey != null) {
+            registeredKeys.put(registrationKey, directory);
+            Set<AbstractWatchService> services = Objects
+                    .requireNonNull(keyToService.computeIfAbsent(registrationKey, k -> new HashSet<>()));
+            services.add(service);
+        } else {
+            logger.debug("The directory '{}' was not registered in the watch service", directory);
+        }
+    }
+
+    public synchronized void stopWatchService(AbstractWatchService service) {
+        List<WatchKey> keysToRemove = new LinkedList<>();
+        for (Map.Entry<WatchKey, Set<AbstractWatchService>> entry : keyToService.entrySet()) {
+            Set<AbstractWatchService> services = entry.getValue();
+            services.remove(service);
+            if (services.isEmpty()) {
+                keysToRemove.add(entry.getKey());
+            }
+        }
+        for (Notification notification : notifications) {
+            if (notification.service.equals(service)) {
+                notification.future.cancel(true);
+                notifications.remove(notification);
+            }
+        }
+        if (keysToRemove.size() == keyToService.size()) {
+            try {
+                WatchService watchService = this.watchService;
+                if (watchService != null) {
+                    watchService.close();
+                    this.watchService = null;
+                }
+            } catch (IOException e) {
+                logger.warn("Cannot deactivate folder watcher", e);
+            }
+            keyToService.clear();
+            registeredKeys.clear();
+            hashes.clear();
+            notifications.forEach(notification -> notification.future.cancel(true));
+            notifications.clear();
+        } else {
+            for (WatchKey key : keysToRemove) {
+                key.cancel();
+                keyToService.remove(key);
+                registeredKeys.remove(key);
+                hashes.remove(service);
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            for (;;) {
+                WatchKey key = null;
+                try {
+                    WatchService watchService = this.watchService;
+                    if (watchService != null) {
+                        key = watchService.take();
+                    }
+                } catch (InterruptedException exc) {
+                    logger.info("Caught InterruptedException: {}", exc.getLocalizedMessage());
+                    return;
+                }
+
+                if (key == null) {
+                    continue;
+                }
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    Kind<?> kind = event.kind();
+                    if (kind == OVERFLOW) {
+                        logger.warn(
+                                "Found an event of kind 'OVERFLOW': {}. File system changes might have been missed.",
+                                event);
+                        continue;
+                    }
+                    Path resolvedPath = resolvePath(key, event);
+
+                    if (resolvedPath != null) {
+                        // Process the event only when a relative path to it is resolved
+                        Set<AbstractWatchService> services;
+                        synchronized (this) {
+                            services = keyToService.get(key);
+                        }
+                        if (services != null) {
+                            File f = resolvedPath.toFile();
+                            if (kind == ENTRY_MODIFY && f.isDirectory()) {
+                                logger.trace("Skipping modification event for directory: {}", f);
+                            } else {
+                                if (kind == ENTRY_MODIFY) {
+                                    processModificationEvent(key, event, resolvedPath, services);
+                                } else {
+                                    services.forEach(s -> s.processWatchEvent(event, kind, resolvedPath));
+                                }
+                            }
+                            if (kind == ENTRY_CREATE && f.isDirectory()) {
+                                for (AbstractWatchService service : services) {
+                                    if (service.watchSubDirectories()
+                                            && service.getWatchEventKinds(resolvedPath) != null) {
+                                        registerDirectoryInternal(service, service.getWatchEventKinds(resolvedPath),
+                                                resolvedPath);
+                                    }
+                                }
+                            } else if (kind == ENTRY_DELETE) {
+                                synchronized (this) {
+                                    WatchKey toCancel = null;
+                                    for (Map.Entry<WatchKey, Path> entry : registeredKeys.entrySet()) {
+                                        if (entry.getValue().equals(resolvedPath)) {
+                                            toCancel = entry.getKey();
+                                            break;
+                                        }
+                                    }
+                                    if (toCancel != null) {
+                                        registeredKeys.remove(toCancel);
+                                        keyToService.remove(toCancel);
+                                        toCancel.cancel();
+                                    }
+
+                                    services.forEach(service -> forgetChecksum(service, resolvedPath));
+                                    Iterator<Notification> it = notifications.iterator();
+                                    while (it.hasNext()) {
+                                        Notification notification = it.next();
+                                        if (notification.path.equals(resolvedPath)) {
+                                            notification.future.cancel(true);
+                                            it.remove();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                key.reset();
+            }
+        } catch (Exception exc) {
+            logger.debug("ClosedWatchServiceException caught! {}. \n{} Stopping ", exc.getLocalizedMessage(),
+                    Thread.currentThread().getName());
+        }
+    }
+
+    /**
+     * Schedules forwarding of the event to the listeners (if applicable).
+     *
+     * By delaying the forwarding, duplicate modification events and those where the actual file-content is not
+     * consistent or empty in between will get skipped and the file system gets a chance to "settle" before the
+     * framework is going to act on it.
+     *
+     * Also, modification events are received for meta-data changes (e.g. last modification timestamp or file
+     * permissions). They are filtered out by comparing the checksums of the file's content.
+     *
+     * See also <a href=
+     * "https://stackoverflow.com/questions/16777869/java-7-watchservice-ignoring-multiple-occurrences-of-the-same-event">thisdiscussion</a>
+     * on Stack Overflow.
+     *
+     * @param key the `WatchKey`
+     * @param event the `WatchEvent` itself
+     * @param resolvedPath the resolved `Path` for this event
+     * @param services a `Set` of `AbstractWatchServices` that subscribe to this event
+     */
+    private void processModificationEvent(WatchKey key, WatchEvent<?> event, Path resolvedPath,
+            Set<AbstractWatchService> services) {
+        synchronized (notifications) {
+            for (AbstractWatchService service : services) {
+                logger.trace("Modification event for {} ", resolvedPath);
+                removeScheduledNotifications(key, service, resolvedPath);
+                ScheduledFuture<?> future = scheduler.schedule(() -> {
+                    logger.trace("Executing job for {}", resolvedPath);
+                    if (removeScheduledNotifications(key, service, resolvedPath)) {
+                        logger.trace("Job removed itself for {}", resolvedPath);
+                    } else {
+                        logger.trace("Job couldn't find itself for {}", resolvedPath);
+                    }
+                    if (checkAndTrackContent(service, resolvedPath)) {
+                        service.processWatchEvent(event, event.kind(), resolvedPath);
+                    } else {
+                        logger.trace("File content '{}' has not changed, skipping modification event", resolvedPath);
+                    }
+                }, PROCESSING_DELAY, TimeUnit.MILLISECONDS);
+                logger.trace("Scheduled processing of {}", resolvedPath);
+                notifications.add(new Notification(key, service, resolvedPath, future));
+            }
+        }
+    }
+
+    private boolean removeScheduledNotifications(WatchKey key, AbstractWatchService service, Path path) {
+        Set<Notification> notifications = this.notifications.stream().filter(f -> f.matches(key, service, path))
+                .collect(Collectors.toSet());
+        if (notifications.size() > 1) {
+            logger.warn("Found more than one notification for {} / {} / {}. This is a bug.", key, service, path);
+        }
+        notifications.forEach(notification -> notification.future.cancel(true));
+        this.notifications.removeAll(notifications);
+        return !notifications.isEmpty();
+    }
+
+    private @Nullable Path resolvePath(WatchKey key, WatchEvent<?> event) {
+        WatchEvent<Path> ev = cast(event);
+        // Context for directory entry event is the file name of entry.
+        Path contextPath = ev.context();
+        List<Path> baseWatchedDir;
+        Path registeredPath;
+        synchronized (this) {
+            baseWatchedDir = keyToService.getOrDefault(key, Set.of()).stream().map(AbstractWatchService::getSourcePath)
+                    .filter(Objects::nonNull).map(Objects::requireNonNull).collect(Collectors.toList());
+            registeredPath = registeredKeys.get(key);
+        }
+        if (registeredPath != null) {
+            // If the path has been registered in the watch service it relative path can be resolved
+            // The context path is resolved by its already registered parent path
+            return registeredPath.resolve(contextPath);
+        }
+
+        logger.warn(
+                "Detected invalid WatchEvent '{}' and key '{}' for entry '{}' in not registered file or directory of '{}'",
+                event, key, contextPath, baseWatchedDir);
+        return null;
+    }
+
+    private byte @Nullable [] hash(Path path) {
+        try {
+            MessageDigest digester = MessageDigest.getInstance("SHA-256");
+            if (!Files.exists(path)) {
+                return null;
+            }
+            try (InputStream is = Files.newInputStream(path)) {
+                byte[] buffer = new byte[4069];
+                int read;
+                do {
+                    read = is.read(buffer);
+                    if (read > 0) {
+                        digester.update(buffer, 0, read);
+                    }
+                } while (read != -1);
+            }
+            return digester.digest();
+        } catch (NoSuchAlgorithmException | IOException e) {
+            logger.debug("Error calculating the hash of file {}", path, e);
+            return null;
+        }
+    }
+
+    /**
+     * Calculate a checksum of the given file and report back whether it has changed since the last time.
+     *
+     * @param service the service determining the scope
+     * @param resolvedPath the file path
+     * @return {@code true} if the file content has changed since the last call to this method
+     */
+    private boolean checkAndTrackContent(AbstractWatchService service, Path resolvedPath) {
+        byte[] newHash = hash(resolvedPath);
+        if (newHash == null) {
+            return true;
+        }
+        Map<Path, byte[]> keyHashes = Objects.requireNonNull(hashes.computeIfAbsent(service, s -> new HashMap<>()));
+        byte[] oldHash = keyHashes.put(resolvedPath, newHash);
+        return oldHash == null || !Arrays.equals(oldHash, newHash);
+    }
+
+    private void forgetChecksum(AbstractWatchService service, Path resolvedPath) {
+        Map<Path, byte[]> keyHashes = hashes.get(service);
+        if (keyHashes != null) {
+            keyHashes.remove(resolvedPath);
+        }
+    }
+
+    /**
+     * The {@link Notification} stores the information of a single notification
+     */
+    private static class Notification {
+        public final WatchKey key;
+        public final AbstractWatchService service;
+        public final Path path;
+        public final ScheduledFuture<?> future;
+
+        private Notification(WatchKey key, AbstractWatchService service, Path path, ScheduledFuture<?> future) {
+            this.key = key;
+            this.service = service;
+            this.path = path;
+            this.future = future;
+        }
+
+        public boolean matches(WatchKey key, AbstractWatchService service, Path path) {
+            return this.key.equals(key) && this.service.equals(service) && this.path.equals(path);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Notification notification = (Notification) o;
+            return key.equals(notification.key) && service.equals(notification.service)
+                    && path.equals(notification.path) && future.equals(notification.future);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, service, path, future);
+        }
+    }
+}

--- a/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/service/AbstractWatchServiceTest.java
+++ b/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/service/AbstractWatchServiceTest.java
@@ -1,0 +1,335 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2021 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.commons.service;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.test.java.JavaTest;
+
+/**
+ * Test for {@link AbstractWatchService}.
+ *
+ * @author Dimitar Ivanov - Initial contribution
+ * @author Svilen Valkanov - Tests are modified to run on different Operating Systems
+ * @author Ana Dimova - reduce to a single watch thread for all class instances
+ * @author Simon Kaufmann - ported it from Groovy to Java
+ * @author Jan N. Klug - null annotations
+ */
+@NonNullByDefault
+public class AbstractWatchServiceTest extends JavaTest {
+    private static final String WATCHED_DIRECTORY = "watchDirectory";
+
+    // Fail if no event has been received within the given timeout
+    private static int noEventTimeoutInSeconds;
+
+    private @Nullable RelativeWatchService watchService;
+
+    @BeforeAll
+    public static void setUpBeforeClass() {
+        // set the NO_EVENT_TIMEOUT_IN_SECONDS according to the operating system used
+        if (Objects.requireNonNullElse(System.getProperty("os.name"), "").startsWith("Mac OS X")) {
+            noEventTimeoutInSeconds = 10;
+        } else {
+            noEventTimeoutInSeconds = 3;
+        }
+    }
+
+    @BeforeEach
+    public void setup() {
+        File watchDir = new File(WATCHED_DIRECTORY);
+        watchDir.mkdirs();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        RelativeWatchService watchService = this.watchService;
+        if (watchService == null) {
+            return;
+        }
+        watchService.deactivate();
+        Assertions.assertNull(watchService.watchQueueReader.getWatchService());
+        final Path watchedDirectory = Paths.get(WATCHED_DIRECTORY);
+        if (Files.exists(watchedDirectory)) {
+            try (Stream<Path> walk = Files.walk(watchedDirectory)) {
+                walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            }
+        }
+        watchService.allFullEvents.clear();
+    }
+
+    @Test
+    public void testInRoot() throws Exception {
+        RelativeWatchService watchService = new RelativeWatchService(WATCHED_DIRECTORY, true);
+        this.watchService = watchService;
+
+        // File created in the watched directory
+        assertByRelativePath(watchService, "rootWatchFile");
+    }
+
+    @Test
+    public void testInSub() throws Exception {
+        RelativeWatchService watchService = new RelativeWatchService(WATCHED_DIRECTORY, true);
+        this.watchService = watchService;
+
+        // File created in a subdirectory of the watched directory
+        assertByRelativePath(watchService, "subDir" + File.separatorChar + "subDirWatchFile");
+    }
+
+    @Test
+    public void testInSubSub() throws Exception {
+        RelativeWatchService watchService = new RelativeWatchService(WATCHED_DIRECTORY, true);
+        this.watchService = watchService;
+
+        // File created in a sub sub directory of the watched directory
+        assertByRelativePath(watchService,
+                "subDir" + File.separatorChar + "subSubDir" + File.separatorChar + "innerWatchFile");
+    }
+
+    @Test
+    public void testIdenticalNames() throws Exception {
+        RelativeWatchService watchService = new RelativeWatchService(WATCHED_DIRECTORY, true);
+        this.watchService = watchService;
+
+        String fileName = "duplicateFile";
+        String innerFileName = "duplicateDir" + File.separatorChar + fileName;
+
+        File innerfile = new File(WATCHED_DIRECTORY + File.separatorChar + innerFileName);
+        Objects.requireNonNull(innerfile.getParentFile()).mkdirs();
+
+        // Activate the service when the subdir is also present. Else the subdir will not be registered
+        watchService.activate();
+
+        innerfile.createNewFile();
+
+        // Assure that the ordering of the events will be always the same
+        Thread.sleep(noEventTimeoutInSeconds * 1000);
+
+        new File(WATCHED_DIRECTORY + File.separatorChar + fileName).createNewFile();
+
+        assertEventCount(watchService, 2);
+
+        FullEvent innerFileEvent = watchService.allFullEvents.get(0);
+        assertThat(innerFileEvent.eventKind, is(ENTRY_CREATE));
+        assertThat(innerFileEvent.eventPath.toString(), is(WATCHED_DIRECTORY + File.separatorChar + innerFileName));
+
+        FullEvent fileEvent = watchService.allFullEvents.get(1);
+        assertThat(fileEvent.eventKind, is(ENTRY_CREATE));
+        assertThat(fileEvent.eventPath.toString(), is(WATCHED_DIRECTORY + File.separatorChar + fileName));
+    }
+
+    @Test
+    public void testExcludeSubdirs() throws Exception {
+        // Do not watch the subdirectories of the root directory
+        RelativeWatchService watchService = new RelativeWatchService(WATCHED_DIRECTORY, false);
+        this.watchService = watchService;
+
+        String innerFileName = "watchRequestSubDir" + File.separatorChar + "watchRequestInnerFile";
+
+        File innerFile = new File(WATCHED_DIRECTORY + File.separatorChar + innerFileName);
+        Objects.requireNonNull(innerFile.getParentFile()).mkdirs();
+
+        watchService.activate();
+
+        // Consequent creation and deletion in order to generate any watch events for the subdirectory
+        innerFile.createNewFile();
+        innerFile.delete();
+
+        assertNoEventsAreProcessed(watchService);
+    }
+
+    @Test
+    public void testIncludeSubdirs() throws Exception {
+        // Do watch the subdirectories of the root directory
+        RelativeWatchService watchService = new RelativeWatchService(WATCHED_DIRECTORY, true);
+        this.watchService = watchService;
+
+        String innerFileName = "watchRequestSubDir" + File.separatorChar + "watchRequestInnerFile";
+        File innerFile = new File(WATCHED_DIRECTORY + File.separatorChar + innerFileName);
+        // Make all the subdirectories before running the service
+        Objects.requireNonNull(innerFile.getParentFile()).mkdirs();
+
+        watchService.activate();
+
+        innerFile.createNewFile();
+        assertFileCreateEventIsProcessed(watchService, innerFile, innerFileName);
+
+        watchService.allFullEvents.clear();
+        assertNoEventsAreProcessed(watchService);
+    }
+
+    private void assertNoEventsAreProcessed(RelativeWatchService watchService) throws Exception {
+        // Wait for a possible event for the maximum timeout
+        Thread.sleep(noEventTimeoutInSeconds * 1000);
+
+        assertEventCount(watchService, 0);
+    }
+
+    private void assertFileCreateEventIsProcessed(RelativeWatchService watchService, File innerFile,
+            String innerFileName) {
+        // Single event for file creation is present
+        assertEventCount(watchService, 1);
+        FullEvent fileEvent = watchService.allFullEvents.get(0);
+        assertThat(fileEvent.eventKind, is(ENTRY_CREATE));
+        assertThat(fileEvent.eventPath.toString(), is(WATCHED_DIRECTORY + File.separatorChar + innerFileName));
+    }
+
+    private void assertByRelativePath(RelativeWatchService watchService, String fileName) throws Exception {
+        File file = new File(WATCHED_DIRECTORY + File.separatorChar + fileName);
+        Objects.requireNonNull(file.getParentFile()).mkdirs();
+
+        assertThat(file.exists(), is(false));
+
+        // We have to be sure that all the subdirectories of the watched directory are created when the watched service
+        // is activated
+        watchService.activate();
+
+        file.createNewFile();
+        fullEventAssertionsByKind(watchService, fileName, ENTRY_CREATE, false);
+
+        // File modified
+        Files.writeString(file.toPath(), "Additional content", StandardOpenOption.APPEND);
+        fullEventAssertionsByKind(watchService, fileName, ENTRY_MODIFY, false);
+
+        // File modified but identical content
+        Files.writeString(file.toPath(), "Additional content", StandardOpenOption.TRUNCATE_EXISTING);
+        assertNoEventsAreProcessed(watchService);
+
+        // File deleted
+        file.delete();
+        fullEventAssertionsByKind(watchService, fileName, ENTRY_DELETE, true);
+    }
+
+    private void assertEventCount(RelativeWatchService watchService, int expected) {
+        try {
+            waitForAssert(() -> assertThat(watchService.allFullEvents.size(), is(expected)));
+        } catch (AssertionError e) {
+            watchService.allFullEvents.forEach(event -> event.toString());
+            throw e;
+        }
+    }
+
+    private void fullEventAssertionsByKind(RelativeWatchService watchService, String fileName, Kind<?> kind,
+            boolean osSpecific) throws Exception {
+        waitForAssert(() -> assertThat(!watchService.allFullEvents.isEmpty(), is(true)), DFL_TIMEOUT * 2,
+                DFL_SLEEP_TIME);
+
+        if (osSpecific && ENTRY_DELETE.equals(kind)) {
+            // There is possibility that one more modify event is triggered on some OS
+            // so sleep a bit extra time
+            Thread.sleep(500);
+            cleanUpOsSpecificModifyEvent(watchService);
+        }
+
+        assertEventCount(watchService, 1);
+        FullEvent fullEvent = watchService.allFullEvents.get(0);
+
+        assertThat(fullEvent.eventPath.toString(), is(WATCHED_DIRECTORY + File.separatorChar + fileName));
+        assertThat(fullEvent.eventKind, is(kind));
+        assertThat(fullEvent.watchEvent.count() >= 1, is(true));
+        assertThat(fullEvent.watchEvent.kind(), is(fullEvent.eventKind));
+        String fileNameOnly = fileName.contains(File.separatorChar + "")
+                ? fileName.substring(fileName.lastIndexOf(File.separatorChar) + 1, fileName.length())
+                : fileName;
+        assertThat(Objects.requireNonNullElse(fullEvent.watchEvent.context(), "").toString(), is(fileNameOnly));
+
+        // Clear all the asserted events
+        watchService.allFullEvents.clear();
+    }
+
+    /**
+     * Cleanup the OS specific ENTRY_MODIFY event as it will not be needed for the assertion
+     */
+    private void cleanUpOsSpecificModifyEvent(RelativeWatchService watchService) {
+        // As the implementation of the watch events is OS specific, it can happen that when the file is deleted two
+        // events are fired - ENTRY_MODIFY followed by an ENTRY_DELETE
+        // This is usually observed on Windows and below is the workaround
+        // Related discussion in StackOverflow:
+        // http://stackoverflow.com/questions/28201283/watchservice-windows-7-when-deleting-a-file-it-fires-both-entry-modify-and-e
+        boolean isDeletedWithPrecedingModify = watchService.allFullEvents.size() == 2
+                && ENTRY_MODIFY.equals(watchService.allFullEvents.get(0).eventKind);
+        if (isDeletedWithPrecedingModify) {
+            // Remove the ENTRY_MODIFY element as it is not needed
+            watchService.allFullEvents.remove(0);
+        }
+    }
+
+    private static class RelativeWatchService extends AbstractWatchService {
+        boolean watchSubDirs;
+
+        // Synchronize list as several watcher threads can write into it
+        public volatile List<FullEvent> allFullEvents = new CopyOnWriteArrayList<>();
+
+        RelativeWatchService(String rootPath, boolean watchSubDirectories) {
+            super(rootPath);
+            watchSubDirs = watchSubDirectories;
+        }
+
+        @Override
+        protected void processWatchEvent(WatchEvent<?> event, Kind<?> kind, Path path) {
+            FullEvent fullEvent = new FullEvent(event, kind, path);
+            allFullEvents.add(fullEvent);
+        }
+
+        @Override
+        protected Kind<?>[] getWatchEventKinds(Path subDir) {
+            return new Kind[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
+        }
+
+        @Override
+        protected boolean watchSubDirectories() {
+            return watchSubDirs;
+        }
+    }
+
+    private static class FullEvent {
+        WatchEvent<?> watchEvent;
+        Kind<?> eventKind;
+        Path eventPath;
+
+        public FullEvent(WatchEvent<?> event, Kind<?> kind, Path path) {
+            watchEvent = event;
+            eventKind = kind;
+            eventPath = path;
+        }
+
+        @Override
+        public String toString() {
+            return "Watch Event: count " + watchEvent.count() + "; kind: " + eventKind + "; path: " + eventPath;
+        }
+    }
+}

--- a/tools/static-code-analysis/checkstyle/rules.xml
+++ b/tools/static-code-analysis/checkstyle/rules.xml
@@ -193,6 +193,9 @@
             <property name="forbiddenPackages" value="${checkstyle.forbiddenPackageUsageCheck.forbiddenPackages}"/>
             <property name="exceptions" value="${checkstyle.forbiddenPackageUsageCheck.exceptions}"/>
         </module>
+        <module name="IllegalImport">
+            <property name="illegalClasses" value="org.openhab.core.service.AbstractWatchService"/>
+        </module>
         <module name="UnusedImports">
             <property name="processJavadoc" value="true"/>
             <property name="severity" value="info"/>


### PR DESCRIPTION
The OHC version if the WatchQueueReader is not capable of having multiple listeners for the same directory. Since the PR with the fix was not accepted, a fixed version is added here.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>