### PR TITLE
[infrastructure] enable building of .kar files 

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -108,8 +108,35 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <targetPath>${project.build.directory}/feature</targetPath>
+        <filtering>true</filtering>
+        <directory>${project.basedir}/src/main/feature</directory>
+      </resource>
+      <resource>
+        <targetPath>${project.build.directory}/kar</targetPath>
+        <directory>${pom.basedir}</directory>
+        <includes>
+          <include>NOTICE</include>
+          <include>README.md</include>
+        </includes>
+      </resource>
+    </resources>
+
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <executions>
+            <execution>
+              <goals>
+                <goal>resources</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
@@ -139,36 +166,9 @@
               <goals>
                 <goal>features-generate-descriptor</goal>
               </goals>
-              <phase>generate-resources</phase>
+              <phase>none</phase>
               <configuration>
                 <inputFile>${feature.directory}</inputFile>
-              </configuration>
-            </execution>
-            <execution>
-              <id>karaf-feature-verification</id>
-              <goals>
-                <goal>verify</goal>
-              </goals>
-              <phase>verify</phase>
-              <configuration>
-                <descriptors combine.children="append">
-                  <!-- Apache Karaf -->
-                  <descriptor>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</descriptor>
-                  <descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
-                  <!-- Current feature under verification -->
-                  <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
-                </descriptors>
-                <distribution>org.apache.karaf.features:framework</distribution>
-                <javase>${oh.java.version}</javase>
-                <framework>
-                  <feature>framework</feature>
-                </framework>
-                <features>
-                  <feature>smarthomej-*</feature>
-                </features>
-                <verifyTransitive>false</verifyTransitive>
-                <ignoreMissingConditions>true</ignoreMissingConditions>
-                <fail>first</fail>
               </configuration>
             </execution>
           </executions>
@@ -259,6 +259,60 @@
               <execution>
                 <id>embed-dependencies</id>
                 <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>create-kar</id>
+      <activation>
+        <file>
+          <exists>src/main/feature/feature.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.karaf.tooling</groupId>
+            <artifactId>karaf-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>karaf-feature-verification</id>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
+                <phase>verify</phase>
+                <configuration>
+                  <descriptors combine.children="append">
+                    <!-- Apache Karaf -->
+                    <descriptor>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</descriptor>
+                    <descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
+                    <!-- Current feature under verification -->
+                    <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
+                  </descriptors>
+                  <distribution>org.apache.karaf.features:framework</distribution>
+                  <javase>${oh.java.version}</javase>
+                  <framework>
+                    <feature>framework</feature>
+                  </framework>
+                  <features>
+                    <feature>smarthomej-*</feature>
+                  </features>
+                  <verifyTransitive>false</verifyTransitive>
+                  <ignoreMissingConditions>true</ignoreMissingConditions>
+                  <fail>first</fail>
+                </configuration>
+              </execution>
+              <execution>
+                <id>create-kar</id>
+                <goals>
+                  <goal>kar</goal>
+                </goals>
+                <configuration>
+                  <resourcesDir>${project.build.directory}/kar</resourcesDir>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -116,11 +116,15 @@
       </resource>
       <resource>
         <targetPath>${project.build.directory}/kar</targetPath>
-        <directory>${pom.basedir}</directory>
+        <directory>${project.basedir}</directory>
         <includes>
           <include>NOTICE</include>
           <include>README.md</include>
         </includes>
+      </resource>
+      <resource>
+        <targetPath>${project.build.directory}/classes</targetPath>
+        <directory>${project.basedir}/src/main/resources</directory>
       </resource>
     </resources>
 


### PR DESCRIPTION
Starting with openHAB 3.2 3rd-party addons will be available in a "marketplace". For best user experience kar files can be used, so dependencies get automatically installed (instead of jars, where the user must take care of that himself). 