### PR TITLE
[infrastructure] improve feature definition

### DIFF
--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.amazonechocontrol-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-amazonechocontrol" description="Amazon Echo Control Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.amazonechocontrol/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.androiddebugbridge-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-androiddebugbridge" description="Android Debug Bridge Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true">mvn:org.smarthomej.addons.bundles/org.smarthomej.commons/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.deconz/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.deconz/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.deconz-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-deconz" description="Dresden Elektronik deCONZ Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-http</feature>

--- a/bundles/org.smarthomej.binding.dmx/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.dmx/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.dmx-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-dmx" description="DMX Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.dmx/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.http/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.http/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.http-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-http" description="HTTP Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true">mvn:org.smarthomej.addons.bundles/org.smarthomej.commons/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.irobot/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.irobot/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.irobot-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-irobot" description="iRobot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-mqtt</feature>

--- a/bundles/org.smarthomej.binding.knx/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.knx/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.knx-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-knx" description="KNX Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<feature>openhab-transport-serial</feature>

--- a/bundles/org.smarthomej.binding.mail/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.mail/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.mail-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-mail" description="Mail Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true">mvn:com.sun.mail/javax.mail/1.6.2</bundle>

--- a/bundles/org.smarthomej.binding.mpd/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.mpd/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.mpd-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-mpd" description="MPD Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.mpd/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.notificationsforfiretv/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.notificationsforfiretv/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.notificationsforfiretv-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-notificationsforfiretv" description="Notifications for Fire TV Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.notificationsforfiretv/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.onewire/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.onewire/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.onewire-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-onewire" description="OneWire Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.onewire/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.snmp/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.snmp/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.snmp-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-snmp" description="SNMP Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.snmp/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.tcpudp/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.tcpudp/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.tcpudp-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-tcpudp" description="TCP/UDP Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true">mvn:org.smarthomej.addons.bundles/org.smarthomej.commons/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.telenot/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.telenot/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.telenot-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-telenot" description="Telenot Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.telenot/${project.version}</bundle>

--- a/bundles/org.smarthomej.binding.tr064/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.tr064/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.binding.tr064-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-binding-tr064" description="TR-064 Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<requirement>openhab.tp;filter:="(feature=jaxb)"</requirement>

--- a/bundles/org.smarthomej.persistence.influxdb/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.persistence.influxdb/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.persistence.influxdb-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-persistence-influxdb" description="InfluxDB Persistence" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.persistence.influxdb/${project.version}</bundle>

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.transform.basicprofiles-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-transformation-basicprofiles" description="Basic Profiles" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="75">mvn:org.smarthomej.addons.bundles/org.smarthomej.transform.basicprofiles/${project.version}</bundle>

--- a/bundles/org.smarthomej.transform.chain/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.transform.chain/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.transform.chain-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-transformation-chain" description="Chain Transformation" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle dependency="true">mvn:org.smarthomej.addons.bundles/org.smarthomej.commons/${project.version}</bundle>

--- a/bundles/org.smarthomej.transform.format/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.transform.format/src/main/feature/feature.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.transform.format-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
-
 	<feature name="smarthomej-transformation-format" description="Format Transformation" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="75">mvn:org.smarthomej.addons.bundles/org.smarthomej.transform.format/${project.version}</bundle>

--- a/bundles/org.smarthomej.transform.math/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.transform.math/src/main/feature/feature.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.smarthomej.transform.math-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features
-	</repository>
-
 	<feature name="smarthomej-transformation-math" description="Math Transformation" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="75">mvn:org.smarthomej.addons.bundles/org.smarthomej.transform.math/${project.version}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -293,6 +293,8 @@
                     <!-- Apache Karaf -->
                     <descriptor>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</descriptor>
                     <descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
+                    <!-- openHAB code -->
+                    <descriptor>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</descriptor>
                     <!-- Current feature under verification -->
                     <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
                   </descriptors>
@@ -316,6 +318,7 @@
                 </goals>
                 <configuration>
                   <resourcesDir>${project.build.directory}/kar</resourcesDir>
+                  <ignoreDependencyFlag>true</ignoreDependencyFlag>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
- dependencies that are not part of core features are also included in the .kar and thus allow installation even if the bundle is not available in the openHAB artifactory
- the core feature repository has been moved from the individual feature.xml to the karaf-maven-plugin configuration which makes the generated .kar files compatible with multiple core versions

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>