### PR TITLE
[infrastructure] fix build order

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -107,6 +107,14 @@
       <type>xml</type>
       <scope>provided</scope>
     </dependency>
+    <!-- External features must be build first due to .kar generation -->
+    <dependency>
+      <groupId>org.smarthomej.addons.features.karaf</groupId>
+      <artifactId>org.smarthomej.addons.features.karaf.smarthomej-addons-external</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -22,14 +22,6 @@
   </modules>
 
   <dependencies>
-    <!-- BOM, so features are build after bundles in parallel builds -->
-    <dependency>
-      <groupId>org.smarthomej.addons.bom</groupId>
-      <artifactId>org.smarthomej.addons.bom.smarthomej-addons</artifactId>
-      <version>${project.version}</version>
-      <type>pom</type>
-    </dependency>
-
     <!-- Distribution -->
     <dependency>
       <groupId>org.apache.karaf.features</groupId>

--- a/features/smarthomej-addons/pom.xml
+++ b/features/smarthomej-addons/pom.xml
@@ -17,6 +17,14 @@
   <description>SmartHome/J Add-ons Features</description>
 
   <dependencies>
+    <!-- BOM, so features are build after bundles in parallel builds -->
+    <dependency>
+      <groupId>org.smarthomej.addons.bom</groupId>
+      <artifactId>org.smarthomej.addons.bom.smarthomej-addons</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+    </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>org.smarthomej.addons.features.karaf.smarthomej-addons-external</artifactId>


### PR DESCRIPTION
The introduction of `.kar` builds makes it necessary to build the `org.smarthomej.addons.features.karaf.smarthomej-addons-external`artifact before the bundles itself are build.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>