### PR TITLE
[infrastructure] fix encoding in documentation html generation

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -101,6 +101,8 @@
         </executions>
         <configuration>
           <inputDirectory>${project.build.directory}/markdown</inputDirectory>
+          <inputEncoding>UTF-8</inputEncoding>
+          <outputEncoding>UTF-8</outputEncoding>
           <outputDirectory>${project.build.directory}/html/${project.version}</outputDirectory>
           <copyDirectories>css</copyDirectories>
           <attributes>


### PR DESCRIPTION
encoding of UTF-8 characters was lost in documentation generation

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>