### PR TITLE
[infrastructure] update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,14 @@
 .DS_Store
 *.iml
 npm-debug.log
+package-lock.json
+package.json
 .build.log
 
 .metadata/
 bin/
 target/
+node_modules/
 src-gen/
 xtend-gen/
 .history/


### PR DESCRIPTION
This is necessary to manage both release-branches (3.2.x needs npm modules for release post creation).

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>