### PR TITLE
[knx] add warning for incompatible DPT type

### DIFF
--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
@@ -80,10 +80,7 @@ public abstract class KNXChannel {
             Map.entry("DateTime", Set.of(DateTimeType.class)), //
             Map.entry("Number", Set.of(DecimalType.class, QuantityType.class)), //
             Map.entry("Rollershutter", Set.of(PercentType.class, UpDownType.class, StopMoveType.class)), //
-            Map.entry("String",
-                    Set.of(OnOffType.class, PercentType.class, OpenClosedType.class, DecimalType.class,
-                            QuantityType.class, StringType.class, DateTimeType.class, IncreaseDecreaseType.class,
-                            UpDownType.class, StopMoveType.class)));
+            Map.entry("String", Set.of(StringType.class)));
 
     KNXChannel(Set<String> gaKeys, Channel channel) {
         this.gaKeys = gaKeys;

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
@@ -35,6 +35,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StopMoveType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.thing.Channel;
@@ -78,9 +79,11 @@ public abstract class KNXChannel {
             Map.entry("Color", Set.of(OnOffType.class, PercentType.class, HSBType.class, IncreaseDecreaseType.class)), //
             Map.entry("DateTime", Set.of(DateTimeType.class)), //
             Map.entry("Number", Set.of(DecimalType.class, QuantityType.class)), //
-            Map.entry("Rollershutter", Set.of(PercentType.class, UpDownType.class)), //
-            Map.entry("String", Set.of(OnOffType.class, PercentType.class, OpenClosedType.class, DecimalType.class,
-                    QuantityType.class, StringType.class, DateTimeType.class)));
+            Map.entry("Rollershutter", Set.of(PercentType.class, UpDownType.class, StopMoveType.class)), //
+            Map.entry("String",
+                    Set.of(OnOffType.class, PercentType.class, OpenClosedType.class, DecimalType.class,
+                            QuantityType.class, StringType.class, DateTimeType.class, IncreaseDecreaseType.class,
+                            UpDownType.class, StopMoveType.class)));
 
     KNXChannel(Set<String> gaKeys, Channel channel) {
         this.gaKeys = gaKeys;

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
@@ -27,6 +27,16 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.types.Type;
@@ -61,6 +71,17 @@ public abstract class KNXChannel {
         this(Set.of(GA), channel);
     }
 
+    private static final Map<String, Set<Class<? extends Type>>> ACCEPTED_TYPES = Map.ofEntries( //
+            Map.entry("Switch", Set.of(OnOffType.class)), //
+            Map.entry("Dimmer", Set.of(OnOffType.class, PercentType.class, IncreaseDecreaseType.class)), //
+            Map.entry("Contact", Set.of(OpenClosedType.class)), //
+            Map.entry("Color", Set.of(OnOffType.class, PercentType.class, HSBType.class, IncreaseDecreaseType.class)), //
+            Map.entry("DateTime", Set.of(DateTimeType.class)), //
+            Map.entry("Number", Set.of(DecimalType.class, QuantityType.class)), //
+            Map.entry("Rollershutter", Set.of(PercentType.class, UpDownType.class)), //
+            Map.entry("String", Set.of(OnOffType.class, PercentType.class, OpenClosedType.class, DecimalType.class,
+                    QuantityType.class, StringType.class, DateTimeType.class)));
+
     KNXChannel(Set<String> gaKeys, Channel channel) {
         this.gaKeys = gaKeys;
 
@@ -75,6 +96,24 @@ public abstract class KNXChannel {
             GroupAddressConfiguration groupAddressConfiguration = GroupAddressConfiguration
                     .parse(configuration.get(key));
             if (groupAddressConfiguration != null) {
+                // check DPT configuration (if set) is compatible with item
+                String dpt = groupAddressConfiguration.getDPT();
+                if (dpt != null) {
+                    Set<Class<? extends Type>> types = KNXCoreTypeMapper.getAllowedTypes(dpt);
+                    String itemType = Objects.requireNonNull(channel.getAcceptedItemType());
+                    if (itemType.contains(":")) {
+                        itemType = itemType.substring(0, itemType.indexOf(":"));
+                    }
+                    Set<Class<? extends Type>> channelTypes = ACCEPTED_TYPES.get(itemType);
+                    if (channelTypes == null) {
+                        logger.debug(
+                                "Could not determine accepted types for channel '{}', assuming DPT assignment is ok.",
+                                channelUID);
+                    } else if (!channelTypes.containsAll(types)) {
+                        logger.warn("Configured DPT '{}' is incompatible with accepted item type '{}' for channel '{}'",
+                                dpt, itemType, channelUID);
+                    }
+                }
                 groupAddressConfigurations.put(key, groupAddressConfiguration);
                 // store address configuration for re-use
                 listenAddresses.addAll(groupAddressConfiguration.getListenGAs());

--- a/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/channel/KNXChannelTest.java
+++ b/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/channel/KNXChannelTest.java
@@ -144,6 +144,7 @@ public class KNXChannelTest {
 
         when(channel.getChannelTypeUID()).thenReturn(new ChannelTypeUID("a:b:c"));
         when(channel.getConfiguration()).thenReturn(configuration);
+        when(channel.getAcceptedItemType()).thenReturn("none");
 
         MyKNXChannel knxChannel = new MyKNXChannel(channel);
 


### PR DESCRIPTION
Configuring incompatible DPT/channel combinations (e.g. DPT 1.005 (alarm) on `Contact` channels or DPT 1.019 (windows/door) on `Switch` channels) is not allowed but was silently ignored. This PR adds a warning in case incompatible configurations are detected.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>