### PR TITLE
[knx] add full UoM support

### DIFF
--- a/bundles/org.smarthomej.binding.knx/README.md
+++ b/bundles/org.smarthomej.binding.knx/README.md
@@ -9,7 +9,12 @@ The KNX binding then can communicate directly with this gateway.
 Alternatively a PC running [KNXD](https://github.com/knxd/knxd) (free open source component sofware) can be put in between which then acts as a broker allowing multiple client to connect to the same gateway.
 Since the protocol is identical, the KNX binding can also communicate with it transparently.
 
-***Attention:*** With the introduction of UoM support in version 3.2.7 (see `number` channel below) the data type for DPT 9.007 has been changed from PercentType to QuantityType.
+***Attention:*** With the introduction of UoM support in version 3.2.7 (see `number` channel below) some data types have changed:
+- the data type for DPT 9.007 (Humidity) has changed from `PercentType` to `QuantityType` 
+- the data type for DPT 5.001 (Percent 8bit, 0 -> 100%) has changed from `PercentType` to `QuantityType`for `number` channels (`dimmer`, `color`, `rollershutter` channels stay with `PercentType`)
+- the data type for DPT 5.004 (Percent 8bit, 0 -> 255%) has changed from `PercentType` to `QuantityType`
+- the data type for DPT 6.001 (Percent 8bit -128 -> 127%) has changed from `PercentType` to `QuantityType`
+
 
 ## Supported Things
 

--- a/bundles/org.smarthomej.binding.knx/README.md
+++ b/bundles/org.smarthomej.binding.knx/README.md
@@ -1,4 +1,3 @@
-
 # KNX Binding
 
 The openHAB KNX binding allows to connect to [KNX Home Automation](https://www.knx.org/) installations.
@@ -9,6 +8,8 @@ This can be either an Ethernet (as a Router or a Tunnel type) or a serial gatewa
 The KNX binding then can communicate directly with this gateway.
 Alternatively a PC running [KNXD](https://github.com/knxd/knxd) (free open source component sofware) can be put in between which then acts as a broker allowing multiple client to connect to the same gateway.
 Since the protocol is identical, the KNX binding can also communicate with it transparently.
+
+***Attention:*** With the introduction of UoM support in version 3.2.7 (see `number` channel below) the data type for DPT 9.007 has been changed from PercentType to QuantityType.
 
 ## Supported Things
 
@@ -115,9 +116,14 @@ A change would break all existing installations and is therefore not implemented
 |-----------|---------------|-------------|
 | ga        | Group address | 9.001       |
 
-*Attention:* When linking the channel to an item that has a dimension (e.g. `Number:Temperature`) the unit is stripped (i.e. no conversion takes place).
-So if you send `23.1 °C` to the item a value of `23.1` will be send to the KNX bus, no matter if you choose DPT 9.001 (which is temperature in degree Celsius and 23.1 is indeed the correct value) or DPT 9.002 (which is temperature in Kelvin where 296.25 would be the correct value).
-If you need other units, you need to use a rule or a profile to convert the value.
+The `number` channel has full support for UoM.
+
+Incoming values from the KNX bus are converted to values with units (e.g. `23 °C`).
+If the channel is linked to the correct item-type (`Number:Temperature` in this case) the display unit can be controlled my item metadata (e.g. `%.1f °F` for 1 digit of precision in Fahrenheit).
+The unit is stripped if the channel is linked to a plain number item (type `Number`). 
+
+Outgoing values with unit are first converted to the unit associated with the DPT (e.g. a value of `10 °F` is converted to `-8.33 °C` if the channel has DPT 9.001).
+Values from plain number channels are sent as-is (without any conversion).
 
 ##### Channel Type "string"
 
@@ -176,6 +182,8 @@ A change would break all existing installations and is therefore not implemented
 | Parameter | Description   | Default DPT |
 |-----------|---------------|-------------|
 | ga        | Group address | 9.001       |
+
+For UoM support see the explanations of the `number` channel.
 
 ##### Channel Type "string-control"
 
@@ -293,13 +301,13 @@ Bridge knx:ip:bridge [
 knx.items:
 
 ```xtend
-Switch        demoSwitch         "Light [%s]"               <light>          { channel="knx:device:bridge:generic:demoSwitch" }
-Dimmer        demoDimmer         "Dimmer [%d %%]"           <light>          { channel="knx:device:bridge:generic:demoDimmer" }
-Rollershutter demoRollershutter  "Shade [%d %%]"            <rollershutter>  { channel="knx:device:bridge:generic:demoRollershutter" }
-Contact       demoContact        "Front Door [%s]"          <frontdoor>      { channel="knx:device:bridge:generic:demoContact" }
-Number        demoTemperature    "Temperature [%.1f °C]"    <temperature>    { channel="knx:device:bridge:generic:demoTemperature" }
-String        demoString         "Message of the day [%s]"                   { channel="knx:device:bridge:generic:demoString" }
-DateTime      demoDatetime       "Alarm [%1$tH:%1$tM]"                       { channel="knx:device:bridge:generic:demoDatetime" }
+Switch              demoSwitch         "Light [%s]"               <light>          { channel="knx:device:bridge:generic:demoSwitch" }
+Dimmer              demoDimmer         "Dimmer [%d %%]"           <light>          { channel="knx:device:bridge:generic:demoDimmer" }
+Rollershutter       demoRollershutter  "Shade [%d %%]"            <rollershutter>  { channel="knx:device:bridge:generic:demoRollershutter" }
+Contact             demoContact        "Front Door [%s]"          <frontdoor>      { channel="knx:device:bridge:generic:demoContact" }
+Number:Temperature  demoTemperature    "Temperature [%.1f °F]"    <temperature>    { channel="knx:device:bridge:generic:demoTemperature" }
+String              demoString         "Message of the day [%s]"                   { channel="knx:device:bridge:generic:demoString" }
+DateTime            demoDatetime       "Alarm [%1$tH:%1$tM]"                       { channel="knx:device:bridge:generic:demoDatetime" }
 ```
 
 knx.sitemap:

--- a/bundles/org.smarthomej.binding.knx/README.md
+++ b/bundles/org.smarthomej.binding.knx/README.md
@@ -10,11 +10,10 @@ Alternatively a PC running [KNXD](https://github.com/knxd/knxd) (free open sourc
 Since the protocol is identical, the KNX binding can also communicate with it transparently.
 
 ***Attention:*** With the introduction of UoM support in version 3.2.7 (see `number` channel below) some data types have changed:
-- the data type for DPT 9.007 (Humidity) has changed from `PercentType` to `QuantityType` 
 - the data type for DPT 5.001 (Percent 8bit, 0 -> 100%) has changed from `PercentType` to `QuantityType`for `number` channels (`dimmer`, `color`, `rollershutter` channels stay with `PercentType`)
 - the data type for DPT 5.004 (Percent 8bit, 0 -> 255%) has changed from `PercentType` to `QuantityType`
 - the data type for DPT 6.001 (Percent 8bit -128 -> 127%) has changed from `PercentType` to `QuantityType`
-
+- the data type for DPT 9.007 (Humidity) has changed from `PercentType` to `QuantityType`
 
 ## Supported Things
 

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
@@ -79,7 +79,7 @@ public abstract class KNXChannel {
             Map.entry("Color", Set.of(OnOffType.class, PercentType.class, HSBType.class, IncreaseDecreaseType.class)), //
             Map.entry("DateTime", Set.of(DateTimeType.class)), //
             Map.entry("Number", Set.of(DecimalType.class, QuantityType.class)), //
-            Map.entry("Rollershutter", Set.of(PercentType.class, UpDownType.class, StopMoveType.class)), //
+            Map.entry("Rollershutter", Set.of(DecimalType.class, UpDownType.class, StopMoveType.class)), //
             Map.entry("String", Set.of(StringType.class)));
 
     KNXChannel(Set<String> gaKeys, Channel channel) {
@@ -109,7 +109,7 @@ public abstract class KNXChannel {
                         logger.debug(
                                 "Could not determine accepted types for channel '{}', assuming DPT assignment is ok.",
                                 channelUID);
-                    } else if (!channelTypes.containsAll(types)) {
+                    } else if (channelTypes.stream().noneMatch(types::contains)) {
                         logger.warn("Configured DPT '{}' is incompatible with accepted item type '{}' for channel '{}'",
                                 dpt, itemType, channelUID);
                     }

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/KNXChannel.java
@@ -79,7 +79,7 @@ public abstract class KNXChannel {
             Map.entry("Color", Set.of(OnOffType.class, PercentType.class, HSBType.class, IncreaseDecreaseType.class)), //
             Map.entry("DateTime", Set.of(DateTimeType.class)), //
             Map.entry("Number", Set.of(DecimalType.class, QuantityType.class)), //
-            Map.entry("Rollershutter", Set.of(DecimalType.class, UpDownType.class, StopMoveType.class)), //
+            Map.entry("Rollershutter", Set.of(PercentType.class, UpDownType.class, StopMoveType.class)), //
             Map.entry("String", Set.of(StringType.class)));
 
     KNXChannel(Set<String> gaKeys, Channel channel) {

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeColor.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeColor.java
@@ -18,6 +18,10 @@ import static org.smarthomej.binding.knx.internal.KNXBindingConstants.*;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.thing.Channel;
 
 import tuwien.auto.calimero.dptxlator.DPTXlator3BitControlled;
@@ -36,7 +40,8 @@ class TypeColor extends KNXChannel {
     public static final Set<String> SUPPORTED_CHANNEL_TYPES = Set.of(CHANNEL_COLOR, CHANNEL_COLOR_CONTROL);
 
     TypeColor(Channel channel) {
-        super(Set.of(SWITCH_GA, POSITION_GA, INCREASE_DECREASE_GA, HSB_GA), channel);
+        super(Set.of(SWITCH_GA, POSITION_GA, INCREASE_DECREASE_GA, HSB_GA),
+                Set.of(OnOffType.class, PercentType.class, HSBType.class, IncreaseDecreaseType.class), channel);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeContact.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeContact.java
@@ -18,6 +18,7 @@ import static org.smarthomej.binding.knx.internal.KNXBindingConstants.*;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.thing.Channel;
 
 import tuwien.auto.calimero.dptxlator.DPTXlatorBoolean;
@@ -33,7 +34,7 @@ class TypeContact extends KNXChannel {
     public static final Set<String> SUPPORTED_CHANNEL_TYPES = Set.of(CHANNEL_CONTACT, CHANNEL_CONTACT_CONTROL);
 
     TypeContact(Channel channel) {
-        super(channel);
+        super(Set.of(OpenClosedType.class), channel);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeDateTime.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeDateTime.java
@@ -18,6 +18,7 @@ import static org.smarthomej.binding.knx.internal.KNXBindingConstants.*;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.thing.Channel;
 
 import tuwien.auto.calimero.dptxlator.DPTXlatorDateTime;
@@ -33,7 +34,7 @@ class TypeDateTime extends KNXChannel {
     public static final Set<String> SUPPORTED_CHANNEL_TYPES = Set.of(CHANNEL_DATETIME, CHANNEL_DATETIME_CONTROL);
 
     TypeDateTime(Channel channel) {
-        super(channel);
+        super(Set.of(DateTimeType.class), channel);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeDimmer.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeDimmer.java
@@ -19,6 +19,9 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.IncreaseDecreaseType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.thing.Channel;
 
 import tuwien.auto.calimero.dptxlator.DPTXlator3BitControlled;
@@ -36,7 +39,8 @@ class TypeDimmer extends KNXChannel {
     public static final Set<String> SUPPORTED_CHANNEL_TYPES = Set.of(CHANNEL_DIMMER, CHANNEL_DIMMER_CONTROL);
 
     TypeDimmer(Channel channel) {
-        super(Set.of(SWITCH_GA, POSITION_GA, INCREASE_DECREASE_GA), channel);
+        super(Set.of(SWITCH_GA, POSITION_GA, INCREASE_DECREASE_GA),
+                Set.of(OnOffType.class, PercentType.class, IncreaseDecreaseType.class), channel);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeNumber.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeNumber.java
@@ -18,6 +18,8 @@ import static org.smarthomej.binding.knx.internal.KNXBindingConstants.*;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.thing.Channel;
 
 /**
@@ -31,7 +33,7 @@ class TypeNumber extends KNXChannel {
     public static final Set<String> SUPPORTED_CHANNEL_TYPES = Set.of(CHANNEL_NUMBER, CHANNEL_NUMBER_CONTROL);
 
     TypeNumber(Channel channel) {
-        super(channel);
+        super(Set.of(DecimalType.class, QuantityType.class), channel);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeRollershutter.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeRollershutter.java
@@ -19,6 +19,9 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StopMoveType;
+import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.thing.Channel;
 
 import tuwien.auto.calimero.dptxlator.DPTXlator8BitUnsigned;
@@ -36,7 +39,8 @@ class TypeRollershutter extends KNXChannel {
             CHANNEL_ROLLERSHUTTER_CONTROL);
 
     TypeRollershutter(Channel channel) {
-        super(Set.of(UP_DOWN_GA, STOP_MOVE_GA, POSITION_GA), channel);
+        super(Set.of(UP_DOWN_GA, STOP_MOVE_GA, POSITION_GA),
+                Set.of(PercentType.class, UpDownType.class, StopMoveType.class), channel);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeString.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeString.java
@@ -18,6 +18,7 @@ import static org.smarthomej.binding.knx.internal.KNXBindingConstants.*;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.Channel;
 
 import tuwien.auto.calimero.dptxlator.DPTXlatorString;
@@ -33,7 +34,7 @@ class TypeString extends KNXChannel {
     public static final Set<String> SUPPORTED_CHANNEL_TYPES = Set.of(CHANNEL_STRING, CHANNEL_STRING_CONTROL);
 
     TypeString(Channel channel) {
-        super(channel);
+        super(Set.of(StringType.class), channel);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeSwitch.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/channel/TypeSwitch.java
@@ -18,6 +18,7 @@ import static org.smarthomej.binding.knx.internal.KNXBindingConstants.*;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Channel;
 
 import tuwien.auto.calimero.dptxlator.DPTXlatorBoolean;
@@ -33,7 +34,7 @@ class TypeSwitch extends KNXChannel {
     public static final Set<String> SUPPORTED_CHANNEL_TYPES = Set.of(CHANNEL_SWITCH, CHANNEL_SWITCH_CONTROL);
 
     TypeSwitch(Channel channel) {
-        super(channel);
+        super(Set.of(OnOffType.class), channel);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapper.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapper.java
@@ -13,13 +13,6 @@
  */
 package org.smarthomej.binding.knx.internal.dpt;
 
-import static org.smarthomej.binding.knx.internal.KNXBindingConstants.CHANNEL_COLOR;
-import static org.smarthomej.binding.knx.internal.KNXBindingConstants.CHANNEL_COLOR_CONTROL;
-import static org.smarthomej.binding.knx.internal.KNXBindingConstants.CHANNEL_DIMMER;
-import static org.smarthomej.binding.knx.internal.KNXBindingConstants.CHANNEL_DIMMER_CONTROL;
-import static org.smarthomej.binding.knx.internal.KNXBindingConstants.CHANNEL_ROLLERSHUTTER;
-import static org.smarthomej.binding.knx.internal.KNXBindingConstants.CHANNEL_ROLLERSHUTTER_CONTROL;
-
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -107,8 +100,6 @@ public class KNXCoreTypeMapper {
     private static final Pattern RGB_PATTERN = Pattern.compile("r:(?<r>\\d+) g:(?<g>\\d+) b:(?<b>\\d+)");
     private static final Pattern DPT_PATTERN = Pattern.compile("^(?<main>[1-9][0-9]{0,2})(?:\\.(?<sub>\\d{3,4}))?$");
 
-    private static final Set<String> PERCENT_TYPE_CHANNELS = Set.of(CHANNEL_DIMMER, CHANNEL_DIMMER_CONTROL,
-            CHANNEL_ROLLERSHUTTER, CHANNEL_ROLLERSHUTTER_CONTROL, CHANNEL_COLOR, CHANNEL_COLOR_CONTROL);
     /**
      * stores the openHAB type class for (supported) KNX datapoint types in a generic way.
      * dptTypeMap stores more specific type class and exceptions.
@@ -278,10 +269,10 @@ public class KNXCoreTypeMapper {
      *
      * @param dptId the DPT of the given data
      * @param data a byte array containing the value
-     * @param channelType the type of the KNXChannel (used to determine if PercentType is supported or not)
+     * @param supportsPercentType whether the KNXChannel supports PercentType or not
      * @return the data converted to an openHAB Type (or null if conversion failed)
      */
-    public static @Nullable Type convertRawDataToType(String dptId, byte[] data, String channelType) {
+    public static @Nullable Type convertRawDataToType(String dptId, byte[] data, boolean supportsPercentType) {
         try {
             DPTXlator translator = TranslatorTypes.createTranslator(0, dptId);
             translator.setData(data);
@@ -402,7 +393,7 @@ public class KNXCoreTypeMapper {
             }
 
             Set<Class<? extends Type>> typeClass = getAllowedTypes(id);
-            if (typeClass.contains(PercentType.class) && PERCENT_TYPE_CHANNELS.contains(channelType)) {
+            if (typeClass.contains(PercentType.class) && supportsPercentType) {
                 return new PercentType(BigDecimal.valueOf(Math.round(translator.getNumericValue())));
             }
             if (typeClass.contains(QuantityType.class)) {

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/DeviceThingHandler.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/DeviceThingHandler.java
@@ -299,7 +299,8 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
                  */
                 if (knxChannel.isControl()) {
                     logger.trace("onGroupWrite isControl");
-                    Type value = KNXCoreTypeMapper.convertRawDataToType(listenSpec.getDPT(), asdu);
+                    Type value = KNXCoreTypeMapper.convertRawDataToType(listenSpec.getDPT(), asdu,
+                            knxChannel.getChannelType());
                     if (value != null) {
                         OutboundSpec commandSpec = knxChannel.getCommandSpec(value);
                         if (commandSpec != null) {
@@ -320,7 +321,7 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
             return;
         }
 
-        Type value = KNXCoreTypeMapper.convertRawDataToType(listenSpec.getDPT(), asdu);
+        Type value = KNXCoreTypeMapper.convertRawDataToType(listenSpec.getDPT(), asdu, knxChannel.getChannelType());
         if (value != null) {
             if (knxChannel.isControl()) {
                 ChannelUID channelUID = knxChannel.getChannelUID();

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/DeviceThingHandler.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/DeviceThingHandler.java
@@ -300,7 +300,7 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
                 if (knxChannel.isControl()) {
                     logger.trace("onGroupWrite isControl");
                     Type value = KNXCoreTypeMapper.convertRawDataToType(listenSpec.getDPT(), asdu,
-                            knxChannel.getChannelType());
+                            knxChannel.supportsPercentType());
                     if (value != null) {
                         OutboundSpec commandSpec = knxChannel.getCommandSpec(value);
                         if (commandSpec != null) {
@@ -321,7 +321,8 @@ public class DeviceThingHandler extends AbstractKNXThingHandler {
             return;
         }
 
-        Type value = KNXCoreTypeMapper.convertRawDataToType(listenSpec.getDPT(), asdu, knxChannel.getChannelType());
+        Type value = KNXCoreTypeMapper.convertRawDataToType(listenSpec.getDPT(), asdu,
+                knxChannel.supportsPercentType());
         if (value != null) {
             if (knxChannel.isControl()) {
                 ChannelUID channelUID = knxChannel.getChannelUID();

--- a/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/channel/KNXChannelTest.java
+++ b/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/channel/KNXChannelTest.java
@@ -159,7 +159,7 @@ public class KNXChannelTest {
 
     private static class MyKNXChannel extends KNXChannel {
         public MyKNXChannel(Channel channel) {
-            super(Set.of("key1", "key2"), channel);
+            super(Set.of("key1", "key2"), Set.of(), channel);
         }
 
         @Override

--- a/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -14,9 +14,15 @@
 package org.smarthomej.binding.knx.internal.dpt;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.smarthomej.binding.knx.internal.dpt.KNXCoreTypeMapper.DPT_UNIT_MAP;
+
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.QuantityType;
@@ -58,5 +64,24 @@ public class KNXCoreTypeMapperTest {
         HSBType expected = HSBType.fromRGB(r, g, b);
 
         assertEquals(expected, KNXCoreTypeMapper.convertRawDataToType("232.600", data));
+    }
+
+    @Test
+    public void unitFix() {
+        Assertions.assertEquals("m/s²", KNXCoreTypeMapper.fixUnit("ms⁻²"));
+        Assertions.assertEquals("1/s", KNXCoreTypeMapper.fixUnit("s⁻¹"));
+        Assertions.assertEquals("Ah", KNXCoreTypeMapper.fixUnit("A h"));
+    }
+
+    private static Stream<String> unitProvider() {
+        return DPT_UNIT_MAP.values().stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("unitProvider")
+    public void unitsValid(String unit) {
+        String valueStr = "1 " + unit;
+        QuantityType<?> value = new QuantityType<>(valueStr);
+        Assertions.assertNotNull(value);
     }
 }

--- a/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -63,7 +63,7 @@ public class KNXCoreTypeMapperTest {
         int b = Integer.parseInt(value.split(" ")[2].split(":")[1]);
         HSBType expected = HSBType.fromRGB(r, g, b);
 
-        assertEquals(expected, KNXCoreTypeMapper.convertRawDataToType("232.600", data, "string"));
+        assertEquals(expected, KNXCoreTypeMapper.convertRawDataToType("232.600", data, false));
     }
 
     @Test

--- a/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -63,7 +63,7 @@ public class KNXCoreTypeMapperTest {
         int b = Integer.parseInt(value.split(" ")[2].split(":")[1]);
         HSBType expected = HSBType.fromRGB(r, g, b);
 
-        assertEquals(expected, KNXCoreTypeMapper.convertRawDataToType("232.600", data));
+        assertEquals(expected, KNXCoreTypeMapper.convertRawDataToType("232.600", data, "string"));
     }
 
     @Test

--- a/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -69,7 +69,6 @@ public class KNXCoreTypeMapperTest {
     @Test
     public void unitFix() {
         Assertions.assertEquals("m/s²", KNXCoreTypeMapper.fixUnit("ms⁻²"));
-        Assertions.assertEquals("1/s", KNXCoreTypeMapper.fixUnit("s⁻¹"));
         Assertions.assertEquals("Ah", KNXCoreTypeMapper.fixUnit("A h"));
     }
 


### PR DESCRIPTION
This adds full support for UoM to the KNX binding. DPT 5.xxx, 6.xxx, 7.xxx, 8.xxx, 9.xxx, 12.xxx, 13.xxx, 14.xxx and 29.xxx are supported by Calimero and also by the binding.

Support is nearly fully backward compatible because `Number` also accepts `QuantityType`. 

Exceptions:
- DPT 5.001: `PercentType` is still used for `color`, `dimmer` and `rollershutter` channels
- DPT 5.004 / DPT 6.001: support for `PercentType` was dropped. The range of the KNX datapoint (0 -> 255% / -128 -> 127%) is not compatible with `PercentType`
- DPT 9.007: support for `PercentType` was dropped as the DPT is labelled "humidity" which makes no sense for other channels than `number`

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>