### PR TITLE
[commons] refactor ColorUtil to commons

### DIFF
--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/GroupThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/GroupThingHandler.java
@@ -39,7 +39,6 @@ import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.smarthomej.binding.deconz.internal.ColorUtil;
 import org.smarthomej.binding.deconz.internal.DeconzDynamicCommandDescriptionProvider;
 import org.smarthomej.binding.deconz.internal.Util;
 import org.smarthomej.binding.deconz.internal.action.GroupActions;
@@ -49,6 +48,7 @@ import org.smarthomej.binding.deconz.internal.dto.GroupMessage;
 import org.smarthomej.binding.deconz.internal.dto.GroupState;
 import org.smarthomej.binding.deconz.internal.dto.Scene;
 import org.smarthomej.binding.deconz.internal.types.ResourceType;
+import org.smarthomej.commons.util.ColorUtil;
 
 import com.google.gson.Gson;
 

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/LightThingHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/LightThingHandler.java
@@ -49,7 +49,6 @@ import org.openhab.core.types.StateDescriptionFragment;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.smarthomej.binding.deconz.internal.ColorUtil;
 import org.smarthomej.binding.deconz.internal.DeconzDynamicCommandDescriptionProvider;
 import org.smarthomej.binding.deconz.internal.DeconzDynamicStateDescriptionProvider;
 import org.smarthomej.binding.deconz.internal.Util;
@@ -57,6 +56,7 @@ import org.smarthomej.binding.deconz.internal.dto.DeconzBaseMessage;
 import org.smarthomej.binding.deconz.internal.dto.LightMessage;
 import org.smarthomej.binding.deconz.internal.dto.LightState;
 import org.smarthomej.binding.deconz.internal.types.ResourceType;
+import org.smarthomej.commons.util.ColorUtil;
 
 import com.google.gson.Gson;
 

--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/util/ColorUtil.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/util/ColorUtil.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.smarthomej.binding.deconz.internal;
+package org.smarthomej.commons.util;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.library.types.HSBType;

--- a/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/util/ColorUtilTest.java
+++ b/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/util/ColorUtilTest.java
@@ -10,11 +10,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.smarthomej.binding.deconz;
+package org.smarthomej.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -22,7 +21,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openhab.core.library.types.HSBType;
-import org.smarthomej.binding.deconz.internal.ColorUtil;
 
 /**
  * The {@link ColorUtilTest} is a test class for the color conversion
@@ -32,8 +30,8 @@ import org.smarthomej.binding.deconz.internal.ColorUtil;
 @NonNullByDefault
 public class ColorUtilTest {
     private static Stream<Arguments> colors() {
-        return List.of(HSBType.BLACK, HSBType.BLUE, HSBType.GREEN, HSBType.RED, HSBType.WHITE,
-                HSBType.fromRGB(127, 94, 19)).stream().map(Arguments::of);
+        return Stream.of(HSBType.BLACK, HSBType.BLUE, HSBType.GREEN, HSBType.RED, HSBType.WHITE,
+                HSBType.fromRGB(127, 94, 19)).map(Arguments::of);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
This moves the ColorUtil class (and the corresponding test) from the deconz binding to the commons classes. That way it can be re-used by other bindings.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>