### PR TITLE
[infrastructure] improve SuppressWarnings handling

### DIFF
--- a/tools/org.eclipse.jdt.core.prefs
+++ b/tools/org.eclipse.jdt.core.prefs
@@ -21,5 +21,5 @@ org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation=warning
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=warning
 org.eclipse.jdt.core.compiler.problem.suppressOptionalErrors=disabled
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled
-org.eclipse.jdt.core.compiler.problem.suppressWarningsNotFullyAnalysed=info
+org.eclipse.jdt.core.compiler.problem.suppressWarningsNotFullyAnalysed=ignore
 org.eclipse.jdt.core.compiler.problem.syntacticNullAnalysisForFields=disabled


### PR DESCRIPTION
This suppresses INFO-level log messages "not analysed" during the build when @SuppressWarnings annotations are used. Since we use only @SuppressWarnings if needed, this is not needded.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>