### PR TITLE
[knx] add parameter for disabling incoming UoM

### DIFF
--- a/bundles/org.smarthomej.binding.knx/README.md
+++ b/bundles/org.smarthomej.binding.knx/README.md
@@ -16,6 +16,11 @@ Since the protocol is identical, the KNX binding can also communicate with it tr
 - the data type for DPT 6.001 (Percent 8bit -128 -> 127%) has changed from `PercentType` to `QuantityType`
 - the data type for DPT 9.007 (Humidity) has changed from `PercentType` to `QuantityType`
 
+Rules that check for or compare states and transformations that expect a raw value might need adjustments.
+If you run into trouble with that and need some time, you can disable UoM support on binding level via the `disableUoM` parameter.
+UoM are enabled by default and need to be disabled manually.
+A new setting is activated immediately without restart.
+
 ## Supported Things
 
 The KNX binding supports two types of bridges, and one type of things to access the KNX bus.
@@ -23,7 +28,8 @@ There is an *ip* bridge to connect to KNX IP Gateways, and a *serial* bridge for
 
 ## Bridges
 
-The following two bridge types are supported. Bridges don't have channels on their own.
+The following two bridge types are supported.
+Bridges don't have channels on their own.
 
 ### IP Gateway
 
@@ -84,8 +90,6 @@ They are used in the common case where the physical state is owned by a device w
 Control channel types (suffix `-control`) are used for cases where the KNX bus does not own the physical state of a device.
 This could be the case if e.g. a lamp from another binding should be controlled by a KNX wall switch.
 If from the KNX bus a `GroupValueRead` telegram is sent to a *-control Channel, the bridge responds with a `GroupValueResponse` telegram to the KNX bus.
-
-Note: After changing the DPT of already existing Channels, openHAB needs to be restarted for the changes to become effective.
 
 ##### Channel Type `color`, `color-control`
 

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/KNXBindingConstants.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/KNXBindingConstants.java
@@ -37,6 +37,10 @@ public class KNXBindingConstants {
 
     public static final String BINDING_ID = "knx";
 
+    // Global config
+    public static final String CONFIG_DISABLE_UOM = "disableUoM";
+    public static boolean DISABLE_UOM = false;
+
     // Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_IP_BRIDGE = new ThingTypeUID(BINDING_ID, "ip");
     public static final ThingTypeUID THING_TYPE_SERIAL_BRIDGE = new ThingTypeUID(BINDING_ID, "serial");

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/ValueDecoder.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/ValueDecoder.java
@@ -12,6 +12,8 @@
  */
 package org.smarthomej.binding.knx.internal.dpt;
 
+import static org.smarthomej.binding.knx.internal.KNXBindingConstants.DISABLE_UOM;
+
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -343,7 +345,7 @@ public class ValueDecoder {
         if (allowedTypes.contains(PercentType.class)
                 && (HSBType.class.equals(preferredType) || PercentType.class.equals(preferredType))) {
             return new PercentType(BigDecimal.valueOf(Math.round(value)));
-        } else if (allowedTypes.contains(QuantityType.class)) {
+        } else if (allowedTypes.contains(QuantityType.class) && !DISABLE_UOM) {
             String unit = DPTUnits.getUnitForDpt(id);
             if (unit != null) {
                 return new QuantityType<>(value + " " + unit);

--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/factory/KNXHandlerFactory.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/factory/KNXHandlerFactory.java
@@ -16,6 +16,7 @@ package org.smarthomej.binding.knx.internal.factory;
 import static org.smarthomej.binding.knx.internal.KNXBindingConstants.*;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -31,6 +32,7 @@ import org.openhab.core.thing.binding.ThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.smarthomej.binding.knx.internal.handler.DeviceThingHandler;
 import org.smarthomej.binding.knx.internal.handler.IPBridgeThingHandler;
@@ -42,8 +44,8 @@ import org.smarthomej.binding.knx.internal.handler.SerialBridgeThingHandler;
  *
  * @author Simon Kaufmann - Initial contribution and API
  */
-@Component(service = ThingHandlerFactory.class, configurationPid = "binding.knx")
 @NonNullByDefault
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.knx")
 public class KNXHandlerFactory extends BaseThingHandlerFactory {
 
     public static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Set.of(THING_TYPE_DEVICE,
@@ -52,8 +54,14 @@ public class KNXHandlerFactory extends BaseThingHandlerFactory {
     private final NetworkAddressService networkAddressService;
 
     @Activate
-    public KNXHandlerFactory(@Reference NetworkAddressService networkAddressService) {
+    public KNXHandlerFactory(@Reference NetworkAddressService networkAddressService, Map<String, Object> config) {
         this.networkAddressService = networkAddressService;
+        modified(config);
+    }
+
+    @Modified
+    protected void modified(Map<String, Object> config) {
+        DISABLE_UOM = (boolean) config.getOrDefault(CONFIG_DISABLE_UOM, false);
     }
 
     @Override

--- a/bundles/org.smarthomej.binding.knx/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.smarthomej.binding.knx/src/main/resources/OH-INF/binding/binding.xml
@@ -6,4 +6,12 @@
 	<name>KNX Binding</name>
 	<description>This binding supports connecting to a KNX bus</description>
 
+	<config-description>
+		<parameter name="disableUoM" type="boolean">
+			<default>false</default>
+			<label>Disable UoM</label>
+			<description>This disables Units of Measurement support for incoming values.</description>
+		</parameter>
+	</config-description>
+
 </binding:binding>


### PR DESCRIPTION
Some users reported issues with rules or transformations that can't properly handle QuantityType inputs. This introduces a binding level configuration parameter for disabling UoM support for incoming values. Outgoing values are not affected.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>