### PR TITLE
[commons] fix Rollershutter item value converter

### DIFF
--- a/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/itemvalueconverter/converter/RollershutterItemConverter.java
+++ b/bundles/org.smarthomej.commons/src/main/java/org/smarthomej/commons/itemvalueconverter/converter/RollershutterItemConverter.java
@@ -87,11 +87,12 @@ public class RollershutterItemConverter extends AbstractTransformingItemConverte
         try {
             BigDecimal value = new BigDecimal(string);
             if (value.compareTo(PercentType.HUNDRED.toBigDecimal()) > 0) {
-                newState = PercentType.HUNDRED;
+                value = PercentType.HUNDRED.toBigDecimal();
             }
             if (value.compareTo(PercentType.ZERO.toBigDecimal()) < 0) {
-                newState = PercentType.ZERO;
+                value = PercentType.ZERO.toBigDecimal();
             }
+            newState = new PercentType(value);
         } catch (NumberFormatException e) {
             // ignore
         }

--- a/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/itemvalueconverter/converter/ConverterTest.java
+++ b/bundles/org.smarthomej.commons/src/test/java/org/smarthomej/commons/itemvalueconverter/converter/ConverterTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.PlayPauseType;
 import org.openhab.core.library.types.PointType;
 import org.openhab.core.library.types.QuantityType;
@@ -159,6 +160,34 @@ public class ConverterTest {
 
         converter.process(content);
         Mockito.verify(updateState).accept(new HSBType("123,34,47"));
+    }
+
+    @Test
+    public void rollerSHutterConverter() {
+        ItemValueConverterChannelConfig cfg = new ItemValueConverterChannelConfig();
+        RollershutterItemConverter converter = new RollershutterItemConverter(updateState, postCommand, sendHttpValue,
+                NoOpValueTransformation.getInstance(), NoOpValueTransformation.getInstance(), cfg);
+
+        // test 0 and 100
+        ContentWrapper content = new ContentWrapper("0".getBytes(StandardCharsets.UTF_8), "UTF-8", null);
+        converter.process(content);
+        Mockito.verify(updateState).accept(PercentType.ZERO);
+        content = new ContentWrapper("100".getBytes(StandardCharsets.UTF_8), "UTF-8", null);
+        converter.process(content);
+        Mockito.verify(updateState).accept(PercentType.HUNDRED);
+
+        // test under/over-range (expect two times total for zero/100
+        content = new ContentWrapper("-1".getBytes(StandardCharsets.UTF_8), "UTF-8", null);
+        converter.process(content);
+        Mockito.verify(updateState, Mockito.times(2)).accept(PercentType.ZERO);
+        content = new ContentWrapper("105".getBytes(StandardCharsets.UTF_8), "UTF-8", null);
+        converter.process(content);
+        Mockito.verify(updateState, Mockito.times(2)).accept(PercentType.HUNDRED);
+
+        // test value
+        content = new ContentWrapper("67".getBytes(StandardCharsets.UTF_8), "UTF-8", null);
+        converter.process(content);
+        Mockito.verify(updateState).accept(new PercentType(67));
     }
 
     public GenericItemConverter createConverter(Function<String, State> fcn) {


### PR DESCRIPTION
`RollershutterItemConverter`s did not properly handle numeric state updates but always returned `UNDEF`. Affects HTTP and TCP/UDP binding.

Also added a test for proper value handling.

Reported on openHAB GitHUB issue tracker.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>