### PR TITLE
[viessmann] config and docs improvement

### DIFF
--- a/bundles/org.smarthomej.binding.viessmann/README.md
+++ b/bundles/org.smarthomej.binding.viessmann/README.md
@@ -5,7 +5,7 @@ It provides features like the ViCare-App.
 
 ## Note / Important
 
-You have to register your ViCare Account at the Viessmann developer portal and create an Client ID.
+You have to register your ViCare Account at the Viessmann developer portal and create a Client ID.
 
 * `name` - `i.e. openhab`
 * `Google reCAPTCHA` - `off`
@@ -30,7 +30,7 @@ Discovery is supported for all devices connected in your account.
 
 The `bridge` thing supports the connection to the Viessmann API.
 
-* `apiKey` (required) The Client ID form the Viessman developer portal 
+* `apiKey` (required) The Client ID from the Viessman developer portal 
 * `user` (required) The E-Mail address which is registered for the ViCare App
 * `password` (required) The password which is registered for the ViCare App
 * `installationId` (optional / it will be discovered) The installation Id which belongs to your installation 

--- a/bundles/org.smarthomej.binding.viessmann/README.md
+++ b/bundles/org.smarthomej.binding.viessmann/README.md
@@ -5,11 +5,15 @@ It provides features like the ViCare-App.
 
 ## Note / Important
 
-You have to register your ViCare Account at the Viessmann developer portal and create an API Key (Client ID).
+You have to register your ViCare Account at the Viessmann developer portal and create an Client ID.
 
 * `name` - `i.e. openhab`
 * `Google reCAPTCHA` - `off`
 * `Redicect URI` - `http://localhost:8080/viessmann/authcode/`
+
+### Hint: 
+
+On the Viessman developer portal you can add more than one RedirectURI by tapping the plus sign.
 
 ## Supported Things
 
@@ -26,7 +30,7 @@ Discovery is supported for all devices connected in your account.
 
 The `bridge` thing supports the connection to the Viessmann API.
 
-* `apiKey` (required) The API Key (Client ID) form the Viessman developer portal 
+* `apiKey` (required) The Client ID form the Viessman developer portal 
 * `user` (required) The E-Mail address which is registered for the ViCare App
 * `password` (required) The password which is registered for the ViCare App
 * `installationId` (optional / it will be discovered) The installation Id which belongs to your installation 

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -28,6 +28,7 @@
 			<parameter name="password" type="text" required="true">
 				<context>Password</context>
 				<description>The password for the given user</description>
+				<context>password</context>
 			</parameter>
 			<parameter name="installationId" type="text" required="false">
 				<label>Installations ID</label>

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -16,38 +16,41 @@
 
 		<config-description>
 			<parameter name="apiKey" type="text" required="true">
-				<label>API Key</label>
-				<description>The API Key (can be obtained by registering an
-					Application on the Viessmann Developer Website)."
+				<label>Client ID</label>
+				<description>The Client ID (can be obtained by registering an
+					Application on the Viessmann Developer Website)
 				</description>
 			</parameter>
 			<parameter name="user" type="text" required="true">
-				<label>User(E-Mail address)</label>
-				<description>The user name for which the application key has been issued</description>
+				<label>E-Mail address</label>
+				<description>The E-Mail address for which the application key has been issued</description>
 			</parameter>
 			<parameter name="password" type="text" required="true">
-				<context>Password</context>
-				<description>The password for the given user</description>
+				<description>The password for the given E-Mail address</description>
 				<context>password</context>
 			</parameter>
 			<parameter name="installationId" type="text" required="false">
 				<label>Installations ID</label>
 				<description>The Installations ID</description>
+				<advanced>true</advanced>
 			</parameter>
 			<parameter name="gatewaySerial" type="text" required="false">
 				<label>GatewaySerial ID</label>
 				<description>The gatewaySerial</description>
+				<advanced>true</advanced>
 			</parameter>
 			<parameter name="apiCallLimit" type="integer" required="false">
 				<label>API call limit</label>
 				<description>The limit how often call the API. For calcutating the time how often the data is queried in
 					seconds</description>
 				<default>1450</default>
+				<advanced>true</advanced>
 			</parameter>
 			<parameter name="bufferApiCommands" type="integer" required="false">
 				<label>Buffer for API commands</label>
 				<description>The buffer for commands. For calcutating the time how often the data is queried in seconds</description>
 				<default>450</default>
+				<advanced>true</advanced>
 			</parameter>
 			<parameter name="pollingInterval" type="integer" required="false" unit="s">
 				<label>Polling Interval</label>
@@ -55,6 +58,7 @@
 				<description>How often the heating should be queried in seconds (If it's set to 0, then the interval will
 					be
 					calculated by the binding)</description>
+				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -26,6 +26,7 @@
 				<description>The E-Mail address for which the application key has been issued</description>
 			</parameter>
 			<parameter name="password" type="text" required="true">
+				<label>Password</label>
 				<description>The password for the given E-Mail address</description>
 				<context>password</context>
 			</parameter>


### PR DESCRIPTION
- fixes the password display in plain text at the bridge thing config
- correct naming of the client ID
- update of the documentation with a better description