### PR TITLE
[telenot] added UNKNOWN msgType

### DIFF
--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
@@ -284,8 +284,14 @@ public abstract class TelenotBridgeHandler extends BaseBridgeHandler {
                             TelenotThingHandler.readyToSendData.set(true);
                             logger.trace("Ready to send data");
                             break;
-                        case INVALID:
+                        case UNKNOWN:
                             logger.warn("Received {} MsgType | hexString: {}", msgType, message);
+                            sendTelenotCommand(TelenotCommand.confirmACK());
+                            TelenotThingHandler.readyToSendData.set(true);
+                            logger.trace("Ready to send data");
+                            break;
+                        case INVALID:
+                            logger.debug("Received {} MsgType | hexString: {}", msgType, message);
                             sendTelenotCommand(TelenotCommand.confirmACK());
                             TelenotThingHandler.readyToSendData.set(true);
                             logger.trace("Ready to send data");

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/TelenotMsgType.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/TelenotMsgType.java
@@ -124,11 +124,9 @@ public enum TelenotMsgType {
         if (mt == null) {
             if (s.matches("^6868(.*)16")) {
                 mt = TelenotMsgType.UNKNOWN;
+            } else {
+                mt = TelenotMsgType.INVALID;
             }
-        }
-
-        if (mt == null) {
-            mt = TelenotMsgType.INVALID;
         }
 
         return mt;

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/TelenotMsgType.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/TelenotMsgType.java
@@ -46,6 +46,7 @@ public enum TelenotMsgType {
     USED_OUTPUT_CONTACTS_INFO,
     USED_SB_CONTACTS_INFO,
     USED_MB_CONTACTS_INFO,
+    UNKNOWN,
     INVALID;
 
     /** hash map from protocol message heading to type */
@@ -117,6 +118,12 @@ public enum TelenotMsgType {
             }
             if (s.matches("^68\\w\\w\\w\\w687302\\w\\w\\w\\w\\w\\w([F|f]{4})0153(.*)16$")) {
                 mt = TelenotMsgType.RESTART;
+            }
+        }
+
+        if (mt == null) {
+            if (s.matches("^6868(.*)16")) {
+                mt = TelenotMsgType.UNKNOWN;
             }
         }
 


### PR DESCRIPTION
This PR adds UNKNOWN msgType. If the msgType isn't known, it will be logged as WARN. 
It also logs INVALID msgType as DEBUG and it will be ignored in the TelenotBridgeHandler.

Signed-off-by: Ronny Grun <ronny.grun@t-online.de>