### PR TITLE
[knx] fix fallback to DecimalType in number conversion

### DIFF
--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/ValueDecoder.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/ValueDecoder.java
@@ -345,16 +345,21 @@ public class ValueDecoder {
         if (allowedTypes.contains(PercentType.class)
                 && (HSBType.class.equals(preferredType) || PercentType.class.equals(preferredType))) {
             return new PercentType(BigDecimal.valueOf(Math.round(value)));
-        } else if (allowedTypes.contains(QuantityType.class) && !DISABLE_UOM) {
+        }
+
+        if (allowedTypes.contains(QuantityType.class) && !DISABLE_UOM) {
             String unit = DPTUnits.getUnitForDpt(id);
             if (unit != null) {
                 return new QuantityType<>(value + " " + unit);
             } else {
                 LOGGER.trace("Could not determine unit for DPT '{}', fallback to plain decimal", id);
             }
-        } else if (allowedTypes.contains(DecimalType.class)) {
+        }
+
+        if (allowedTypes.contains(DecimalType.class)) {
             return new DecimalType(value);
         }
+
         LOGGER.warn("Failed to convert '{}' (DPT '{}'): no matching type found", value, id);
         return null;
     }


### PR DESCRIPTION
This fixes a regression introduced in #208 which results in erroneous handling of values received from the KNX bus without unit.

Signed-off-by: Jan N. Klug <github@klug.nrw>