### PR TITLE
[amazonechocontrol] fix first-time login

### DIFF
--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/connection/LoginData.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/connection/LoginData.java
@@ -51,7 +51,7 @@ public class LoginData {
     public @Nullable Date loginTime;
     private List<Cookie> cookies = new ArrayList<>();
 
-    public LoginData(CookieManager cookieManager, String frc, String serial, String deviceId) {
+    public LoginData(CookieManager cookieManager, String deviceId, String frc, String serial) {
         this.cookieManager = cookieManager;
         this.frc = frc;
         this.serial = serial;


### PR DESCRIPTION
This was reported on the forum and is a regression introduced in #237 (wrong ordering of constructor parameters),

Signed-off-by: Jan N. Klug <github@klug.nrw>