### PR TITLE
[amazonechocontrol] fix update interval for skill connected smarthome devices

### DIFF
--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/smarthome/SmartHomeDeviceStateGroupUpdateCalculator.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/smarthome/SmartHomeDeviceStateGroupUpdateCalculator.java
@@ -35,11 +35,11 @@ import org.smarthomej.binding.amazonechocontrol.internal.jsons.JsonSmartHomeDevi
 public class SmartHomeDeviceStateGroupUpdateCalculator {
     private final Logger logger = LoggerFactory.getLogger(SmartHomeDeviceStateGroupUpdateCalculator.class);
 
-    private static final Integer UPDATE_INTERVAL_PRIVATE_SKILLS_IN_SECONDS = 10;
-    private static final Integer UPDATE_INTERVAL_PRIVATE_SKILLS_IN_SECONDS_TRACE = 600;
-    private static final Integer UPDATE_INTERVAL_ACOUSTIC_EVENTS_IN_SECONDS = 10;
-    private Integer updateIntervalAmazonInSeconds;
-    private Integer updateIntervalSkillsInSeconds;
+    private static final int UPDATE_INTERVAL_PRIVATE_SKILLS_IN_SECONDS = 300;
+    private static final int UPDATE_INTERVAL_PRIVATE_SKILLS_IN_SECONDS_TRACE = 10;
+    private static final int UPDATE_INTERVAL_ACOUSTIC_EVENTS_IN_SECONDS = 10;
+    private final int updateIntervalAmazonInSeconds;
+    private final int updateIntervalSkillsInSeconds;
 
     private static class UpdateGroup {
         private final int intervalInSeconds;


### PR DESCRIPTION
The switch between debug and normal update interval was wrong and results in unnecessary load on remote servers.

Signed-off-by: Jan N. Klug <github@klug.nrw>