### PR TITLE
fix build

### DIFF
--- a/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/UtilTest.java
+++ b/bundles/org.smarthomej.binding.http/src/test/java/org/smarthomej/binding/http/UtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the SmartHome/J project
+ * Copyright (c) 2021-2022 Contributors to the SmartHome/J project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.


### PR DESCRIPTION
Licence header was wrong after year change

Signed-off-by: Jan N. Klug <github@klug.nrw>