### PR TITLE
[telenot] update docs / support update system time

### DIFF
--- a/bundles/org.smarthomej.binding.telenot/README.md
+++ b/bundles/org.smarthomej.binding.telenot/README.md
@@ -10,6 +10,17 @@ To get the serial data to the ethernet bus use the following converter or anothe
 Connect this module to the GMS-Port (Serial).
 You have to enable the GMS-Protocol in the CompasX Software.
 
+
+Adapter Config:
+
+```
+Baud Rate：9600 bps
+Data Size：   8 bit
+Parity:        none
+Stop Bits：   1 bit
+Mode:    TCP Server
+```
+
 ## Note
 
 The Building management protocol is a two-way street. 
@@ -47,6 +58,8 @@ The `ipbridge` thing supports a TCP/IP connection to an RS323 to LAN adapter.
 * `hostname` (required) The hostname or IP address of the serial to LAN adapter
 * `tcpPort` (default = 4116) TCP port number for the serial to LAN adapter connection
 * `discovery` Enables the discovery
+* `updateClock` The period in hours that updates the clock on the telenot system.
+Set to 0 to disable.
 * `reconnect` (1-60, default = 2) The period in minutes that the handler will wait between connection checks and connection attempts
 * `timeout` (0-60, default = 5) The period in minutes after which the connection will be reset if no valid messages have been received. Set to 0 to disable.
 
@@ -59,13 +72,15 @@ Bridge telenot:ipbridge:device [ hostname="xxx.xxx.xxx.xxx", tcpPort=4116 ] {
 }
 ```
 
-### `input`
+### `input` and `output`
 
 The `input` thing provides all channels with the state of each single reporting group.
+The `output` thing provides all channels with the state of each single reporting area.
 
-### `ouput`
-
-The `input` thing provides all channels with the state of each single reporting area.
+* 1. Add things
+* 2. Enable discovery in the `ipbridge` thing
+* 3. Now all available channel will be added automatically
+     The discovery takes about 5 minutes.
 
 ### `mb`
 

--- a/bundles/org.smarthomej.binding.telenot/README.md
+++ b/bundles/org.smarthomej.binding.telenot/README.md
@@ -58,7 +58,7 @@ The `ipbridge` thing supports a TCP/IP connection to an RS323 to LAN adapter.
 * `hostname` (required) The hostname or IP address of the serial to LAN adapter
 * `tcpPort` (default = 4116) TCP port number for the serial to LAN adapter connection
 * `discovery` Enables the discovery
-* `updateClock` The period in hours that updates the clock on the telenot system.
+* `updateClock` The period in hours for updating the clock on the telenot system.
 Set to 0 to disable.
 * `reconnect` (1-60, default = 2) The period in minutes that the handler will wait between connection checks and connection attempts
 * `timeout` (0-60, default = 5) The period in minutes after which the connection will be reset if no valid messages have been received. Set to 0 to disable.
@@ -77,9 +77,9 @@ Bridge telenot:ipbridge:device [ hostname="xxx.xxx.xxx.xxx", tcpPort=4116 ] {
 The `input` thing provides all channels with the state of each single reporting group.
 The `output` thing provides all channels with the state of each single reporting area.
 
-* 1. Add things
-* 2. Enable discovery in the `ipbridge` thing
-* 3. Now all available channel will be added automatically
+* 1. Add things.
+* 2. Enable discovery in the `ipbridge` thing.
+* 3. All available channel will be added automatically.
      The discovery takes about 5 minutes.
 
 ### `mb`

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/config/IPBridgeConfig.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/config/IPBridgeConfig.java
@@ -25,6 +25,7 @@ public class IPBridgeConfig {
     public @Nullable String hostname;
     public int tcpPort = 4116;
     public boolean discovery = false;
+    public int updateClock = 24;
     public int reconnect = 2;
     public int refreshData = 10;
     public int timeout = 5;

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/IPBridgeHandler.java
@@ -169,6 +169,13 @@ public class IPBridgeHandler extends TelenotBridgeHandler {
             refreshSendDataJob = null;
         }
 
+        ScheduledFuture<?> ucJob = updateTelenotClockJob;
+        if (ucJob != null) {
+            // use cancel(false) so we don't kill ourselves when reconnect job calls disconnect()
+            ucJob.cancel(false);
+            updateTelenotClockJob = null;
+        }
+
         // Must close the socket first so the message reader thread will exit properly.
         Socket s = socket;
         if (s != null) {

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
@@ -100,6 +100,7 @@ public abstract class TelenotBridgeHandler extends BaseBridgeHandler {
     protected @Nullable ScheduledFuture<?> connectionCheckJob;
     protected @Nullable ScheduledFuture<?> refreshSendDataJob;
     protected @Nullable ScheduledFuture<?> connectRetryJob;
+    protected @Nullable ScheduledFuture<?> updateTelenotClockJob;
 
     public TelenotBridgeHandler(Bridge bridge) {
         super(bridge);

--- a/bundles/org.smarthomej.binding.telenot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.telenot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -28,6 +28,13 @@
 				<description>Enable automatic discovery. After saving this, it goes to off and the discovery will start. </description>
 				<default>false</default>
 			</parameter>
+			<parameter name="updateClock" type="integer" min="0" max="24" unit="h">
+				<label>Update Telenot system clock</label>
+				<description>The period in hours that the binding updates the Telenot system clock. Set 0 to disable.</description>
+				<unitLabel>hours</unitLabel>
+				<default>24</default>
+				<advanced>true</advanced>
+			</parameter>
 			<parameter name="refreshData" type="integer" min="0" max="60" unit="min">
 				<label>Refresh Data Interval</label>
 				<description>The period in minutes that the handler will refresh the data to eventbus</description>


### PR DESCRIPTION
Updates the docs with better installation description. Reported on [https://github.com/michelde/telenot/issues/14#](https://github.com/michelde/telenot/issues/14#issuecomment-1010313982)

Adds the ability to update the time of the Telenot system at intervals through the bridge thing.

Signed-off-by: Ronny Grun <ronny.grun@t-online.de>