### PR TITLE
[telenot] fix channel naming with umlauts and fix reconnection

### DIFF
--- a/bundles/org.smarthomej.binding.telenot/README.md
+++ b/bundles/org.smarthomej.binding.telenot/README.md
@@ -14,10 +14,10 @@ You have to enable the GMS-Protocol in the CompasX Software.
 Adapter Config:
 
 ```
-Baud Rate：9600 bps
-Data Size：   8 bit
+Baud Rate: 9600 bps
+Data Size:    8 bit
 Parity:        none
-Stop Bits：   1 bit
+Stop Bits:    1 bit
 Mode:    TCP Server
 ```
 

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/config/IPBridgeConfig.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/config/IPBridgeConfig.java
@@ -25,7 +25,7 @@ public class IPBridgeConfig {
     public @Nullable String hostname;
     public int tcpPort = 4116;
     public boolean discovery = false;
-    public int updateClock = 24;
+    public int updateClock = 0;
     public int reconnect = 2;
     public int refreshData = 10;
     public int timeout = 5;

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/IPBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/IPBridgeHandler.java
@@ -181,8 +181,11 @@ public class IPBridgeHandler extends TelenotBridgeHandler {
         if (s != null) {
             try {
                 s.close();
+                Thread.sleep(2000);
             } catch (IOException e) {
                 logger.debug("error closing socket: {}", e.getMessage());
+            } catch (InterruptedException e) {
+                logger.debug("waiting after closing socket fails: {}", e.getMessage());
             }
         }
         socket = null;

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
@@ -82,6 +82,7 @@ public abstract class TelenotBridgeHandler extends BaseBridgeHandler {
     private final Object lock = new Object();
     protected @Nullable TelenotDiscoveryService discoveryService;
     protected boolean discovery;
+    protected boolean discoveryStarted = false;
     protected boolean refresh;
     protected volatile @Nullable Date lastReceivedTime;
     protected volatile boolean writeException;
@@ -303,6 +304,10 @@ public abstract class TelenotBridgeHandler extends BaseBridgeHandler {
                 } catch (MessageParseException e) {
                     logger.warn("Error {} while parsing message {}. Please report bug.", e.getMessage(), message);
                 }
+                if (discoveryStarted && usedInputContact.isEmpty() && usedReportingArea.isEmpty()) {
+                    discoveryStarted = false;
+                    logger.info("Discovery job completed");
+                }
             }
 
             if (message == null) {
@@ -482,6 +487,7 @@ public abstract class TelenotBridgeHandler extends BaseBridgeHandler {
      * @throws MessageParseException
      */
     private void parseUsedContactInfoMessage(TelenotMsgType mt, String msg) throws MessageParseException {
+        discoveryStarted = true;
         logger.trace("MSG: {}", msg);
         if (mt == TelenotMsgType.USED_CONTACTS_INFO && !usedInputContact.isEmpty()) {
             UsedContactInfoMessage uciStateMessage;

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/UsedContactInfoMessage.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/UsedContactInfoMessage.java
@@ -12,7 +12,10 @@
  */
 package org.smarthomej.binding.telenot.internal.protocol;
 
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.util.HexUtils;
 import org.smarthomej.binding.telenot.internal.TelenotMessageException;
 
 /**
@@ -30,7 +33,6 @@ public class UsedContactInfoMessage extends TelenotMessage {
 
     public UsedContactInfoMessage(String message) throws TelenotMessageException {
         super(message);
-        StringBuilder strBuilder = new StringBuilder();
 
         String parts[] = message.split(":");
 
@@ -46,29 +48,8 @@ public class UsedContactInfoMessage extends TelenotMessage {
         stringLen = msg.substring(16 + stateMsgLength, 16 + stateMsgLength + 2);
         int nameMsgLength = Integer.parseInt(stringLen, 16) * 2;
         String contactNameHex = msg.substring(20 + stateMsgLength, 20 + stateMsgLength + nameMsgLength);
-
-        int contactHexLen = contactNameHex.length();
-        int b = 0;
-        while (b < contactHexLen) {
-            String hex = contactNameHex.substring(b, b + 2);
-            switch (hex) {
-                case "E1":
-                    strBuilder.append("ä");
-                    break;
-                case "EF":
-                    strBuilder.append("ö");
-                    break;
-                case "F5":
-                    strBuilder.append("ü");
-                    break;
-                default:
-                    Integer charcode = Integer.parseInt(hex, 16);
-                    strBuilder.append(String.valueOf(Character.toChars(charcode)));
-                    break;
-            }
-            b = b + 2;
-        }
-        String strcontact = strBuilder.toString();
+        String strcontact = new String(HexUtils.hexToBytes(contactNameHex), StandardCharsets.ISO_8859_1)
+                .replace("á", "ä").replace("ï", "ö").replace("õ", "ü");
 
         try {
             address = parts[0];

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/UsedContactInfoMessage.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/UsedContactInfoMessage.java
@@ -50,8 +50,22 @@ public class UsedContactInfoMessage extends TelenotMessage {
         int contactHexLen = contactNameHex.length();
         int b = 0;
         while (b < contactHexLen) {
-            Integer charcode = Integer.parseInt(contactNameHex.substring(b, b + 2), 16);
-            strBuilder.append(String.valueOf(Character.toChars(charcode)));
+            String hex = contactNameHex.substring(b, b + 2);
+            switch (hex) {
+                case "E1":
+                    strBuilder.append("ä");
+                    break;
+                case "EF":
+                    strBuilder.append("ö");
+                    break;
+                case "F5":
+                    strBuilder.append("ü");
+                    break;
+                default:
+                    Integer charcode = Integer.parseInt(hex, 16);
+                    strBuilder.append(String.valueOf(Character.toChars(charcode)));
+                    break;
+            }
             b = b + 2;
         }
         String strcontact = strBuilder.toString();

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/UsedMbMessage.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/UsedMbMessage.java
@@ -50,8 +50,22 @@ public class UsedMbMessage extends TelenotMessage {
         int contactHexLen = contactNameHex.length();
         int b = 0;
         while (b < contactHexLen) {
-            Integer charcode = Integer.parseInt(contactNameHex.substring(b, b + 2), 16);
-            strBuilder.append(String.valueOf(Character.toChars(charcode)));
+            String hex = contactNameHex.substring(b, b + 2);
+            switch (hex) {
+                case "E1":
+                    strBuilder.append("ä");
+                    break;
+                case "EF":
+                    strBuilder.append("ö");
+                    break;
+                case "F5":
+                    strBuilder.append("ü");
+                    break;
+                default:
+                    Integer charcode = Integer.parseInt(hex, 16);
+                    strBuilder.append(String.valueOf(Character.toChars(charcode)));
+                    break;
+            }
             b = b + 2;
         }
         String strcontact = strBuilder.toString();

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/UsedMbMessage.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/UsedMbMessage.java
@@ -12,7 +12,10 @@
  */
 package org.smarthomej.binding.telenot.internal.protocol;
 
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.util.HexUtils;
 import org.smarthomej.binding.telenot.internal.TelenotMessageException;
 
 /**
@@ -30,7 +33,6 @@ public class UsedMbMessage extends TelenotMessage {
 
     public UsedMbMessage(String message) throws TelenotMessageException {
         super(message);
-        StringBuilder strBuilder = new StringBuilder();
 
         String parts[] = message.split(":");
 
@@ -46,29 +48,8 @@ public class UsedMbMessage extends TelenotMessage {
         stringLen = msg.substring(16 + stateMsgLength, 16 + stateMsgLength + 2);
         int nameMsgLength = Integer.parseInt(stringLen, 16) * 2;
         String contactNameHex = msg.substring(20 + stateMsgLength, 20 + stateMsgLength + nameMsgLength);
-
-        int contactHexLen = contactNameHex.length();
-        int b = 0;
-        while (b < contactHexLen) {
-            String hex = contactNameHex.substring(b, b + 2);
-            switch (hex) {
-                case "E1":
-                    strBuilder.append("ä");
-                    break;
-                case "EF":
-                    strBuilder.append("ö");
-                    break;
-                case "F5":
-                    strBuilder.append("ü");
-                    break;
-                default:
-                    Integer charcode = Integer.parseInt(hex, 16);
-                    strBuilder.append(String.valueOf(Character.toChars(charcode)));
-                    break;
-            }
-            b = b + 2;
-        }
-        String strcontact = strBuilder.toString();
+        String strcontact = new String(HexUtils.hexToBytes(contactNameHex), StandardCharsets.ISO_8859_1)
+                .replace("á", "ä").replace("ï", "ö").replace("õ", "ü");
 
         try {
             address = parts[0];

--- a/bundles/org.smarthomej.binding.telenot/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.telenot/src/main/resources/OH-INF/thing/thing-types.xml
@@ -21,7 +21,7 @@
 			<parameter name="tcpPort" type="integer">
 				<label>TCP Port</label>
 				<description>TCP port number for the Telenot connection</description>
-				<default>20108</default>
+				<default>4116</default>
 			</parameter>
 			<parameter name="discovery" type="boolean">
 				<label>Enable Discovery</label>
@@ -29,10 +29,10 @@
 				<default>false</default>
 			</parameter>
 			<parameter name="updateClock" type="integer" min="0" max="24" unit="h">
-				<label>Update Telenot system clock</label>
+				<label>Update Telenot's clock</label>
 				<description>The period in hours that the binding updates the Telenot system clock. Set 0 to disable.</description>
 				<unitLabel>hours</unitLabel>
-				<default>24</default>
+				<default>0</default>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="refreshData" type="integer" min="0" max="60" unit="min">


### PR DESCRIPTION
This PR contains following fixes:

1. Channel naming with umlauts have the wrong char. Telenot provides the wrong hex value for the charset. 
2. Some RS232 to Ethernet needs a delay between disconnect and reconnect.

