### PR TITLE
[viessmann] add support for Vitocal heat pump

### DIFF
--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/ViessmannBindingConstants.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/ViessmannBindingConstants.java
@@ -72,7 +72,9 @@ public class ViessmannBindingConstants {
             "percent", Units.PERCENT.toString(), //
             "minute", Units.MINUTE.toString(), //
             "hour", Units.HOUR.toString(), //
-            "hours", Units.HOUR.toString());
+            "hours", Units.HOUR.toString(), //
+            "liter", Units.LITRE.toString(), //
+            "cubicMeter", SIUnits.CUBIC_METRE.toString());
 
     public static Map<String, String> readPropertiesFile(String filename) {
         InputStream resource = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename);

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/ViessmannBindingConstants.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/ViessmannBindingConstants.java
@@ -67,10 +67,12 @@ public class ViessmannBindingConstants {
 
     public static final Map<String, String> UNIT_MAP = Map.of( //
             "celsius", SIUnits.CELSIUS.getSymbol(), //
+            "kelvin", Units.KELVIN.toString(), //
             "kilowattHour", Units.KILOWATT_HOUR.toString(), //
             "percent", Units.PERCENT.toString(), //
             "minute", Units.MINUTE.toString(), //
-            "hour", Units.HOUR.toString());
+            "hour", Units.HOUR.toString(), //
+            "hours", Units.HOUR.toString());
 
     public static Map<String, String> readPropertiesFile(String filename) {
         InputStream resource = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename);

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/api/ViessmannApi.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/api/ViessmannApi.java
@@ -288,8 +288,14 @@ public class ViessmannApi {
                                 String.format("API Call limit reached. Reset at {}",
                                         viError.getExtendedPayload().getLimitRestetDateTime()));
                     } else {
-                        logger.warn("ViError: {} | Reason: {}", viError.getMessage(),
-                                viError.getExtendedPayload().getReason());
+                        if (viError.getExtendedPayload() != null) {
+                            logger.warn("ViError: {} | Reason: {} {}", viError.getMessage(),
+                                    viError.getExtendedPayload().getReason(),
+                                    viError.getExtendedPayload().getDetails());
+                        } else {
+                            logger.warn("ViError: {}", viError.getMessage());
+                        }
+
                     }
                 }
                 return false;

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/api/ViessmannApi.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/api/ViessmannApi.java
@@ -288,14 +288,7 @@ public class ViessmannApi {
                                 String.format("API Call limit reached. Reset at {}",
                                         viError.getExtendedPayload().getLimitRestetDateTime()));
                     } else {
-                        if (viError.getExtendedPayload() != null) {
-                            logger.warn("ViError: {} | Reason: {} {}", viError.getMessage(),
-                                    viError.getExtendedPayload().getReason(),
-                                    viError.getExtendedPayload().getDetails());
-                        } else {
-                            logger.warn("ViError: {}", viError.getMessage());
-                        }
-
+                        logger.warn("ViError: {} | Reason: {}", viError.getMessage(), viError.getExtendedPayload());
                     }
                 }
                 return false;

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/device/DeviceDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/device/DeviceDTO.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.device;
 import java.util.List;
 
 /**
- * The {@link DeviceDTO} is responsible for
+ * The {@link DeviceDTO} provides a device list
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/device/DeviceData.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/device/DeviceData.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.device;
 import java.util.List;
 
 /**
- * The {@link DeviceData} is responsible for
+ * The {@link DeviceData} provides all data of a device
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/ExtendedPayload.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/ExtendedPayload.java
@@ -28,9 +28,15 @@ public class ExtendedPayload {
     private String clientId;
     private String userId;
     private Long limitReset;
+    public String code;
+    public String details;
 
     public String getReason() {
-        return reason;
+        if (reason != null) {
+            return reason;
+        } else {
+            return "";
+        }
     }
 
     public void setReason(String reason) {
@@ -80,5 +86,17 @@ public class ExtendedPayload {
 
     public void setLimitReset(Long limitReset) {
         this.limitReset = limitReset;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDetails() {
+        if (details != null) {
+            return details;
+        } else {
+            return "";
+        }
     }
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/ExtendedPayload.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/ExtendedPayload.java
@@ -15,9 +15,12 @@ package org.smarthomej.binding.viessmann.internal.dto.error;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * The {@link ExtendedPayload} is responsible for
+ * The {@link ExtendedPayload} provides the extended payload of a viessmann error message
  *
  * @author Ronny Grun - Initial contribution
  */
@@ -32,11 +35,7 @@ public class ExtendedPayload {
     public String details;
 
     public String getReason() {
-        if (reason != null) {
-            return reason;
-        } else {
-            return "";
-        }
+        return reason;
     }
 
     public void setReason(String reason) {
@@ -93,10 +92,11 @@ public class ExtendedPayload {
     }
 
     public String getDetails() {
-        if (details != null) {
-            return details;
-        } else {
-            return "";
-        }
+        return details;
+    }
+
+    @Override
+    public @NonNullByDefault String toString() {
+        return Objects.requireNonNullElse(reason, "") + " " + Objects.requireNonNullElse(details, "");
     }
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/TokenErrorDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/TokenErrorDTO.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.error;
 
 /**
- * The {@link TokenErrorDTO} provides the token error message 
+ * The {@link TokenErrorDTO} provides the token error message
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/TokenErrorDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/TokenErrorDTO.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.error;
 
 /**
- * The {@link TokenErrorDTO} is responsible for
+ * The {@link TokenErrorDTO} provides the token error message 
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/ViErrorDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/error/ViErrorDTO.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.error;
 
 /**
- * The {@link ViErrorDTO} is responsible for
+ * The {@link ViErrorDTO} provides the viessmann error message
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureBoolean.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureBoolean.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureBoolean} is responsible for
+ * The {@link FeatureBoolean} provides values of boolean features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureChangeEndDate.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureChangeEndDate.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureChangeEndDate} is responsible for
+ * The {@link FeatureChangeEndDate} provides data of change end date features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureChangeEndDateParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureChangeEndDateParams.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureChangeEndDateParams} is responsible for
+ * The {@link FeatureChangeEndDateParams} provides parameters of change end date features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureCommands.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureCommands.java
@@ -31,6 +31,10 @@ public class FeatureCommands {
     public FeatureSchedule schedule;
     public FeatureDefaultCommands unschedule;
     public FeatureSetTargetTemperature setTargetTemperature;
+    public FeatureSetTargetTemperature setMin;
+    public FeatureSetTargetTemperature setMax;
+    public FeatureSetLevels setLevels;
+    public FeatureSetHysteresis setHysteresis;
 
     public ArrayList<String> getUsedCommands() {
         ArrayList<String> list = new ArrayList<String>();
@@ -66,6 +70,9 @@ public class FeatureCommands {
         }
         if (setTargetTemperature != null) {
             list.add("setTargetTemperature");
+        }
+        if (setHysteresis != null) {
+            list.add("setHysteresis");
         }
         return list;
     }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureCommands.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureCommands.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
 import java.util.ArrayList;
 
 /**
- * The {@link FeatureCommands} is responsible for
+ * The {@link FeatureCommands} provides command of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsEmpty.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsEmpty.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureConstraintsEmpty} is responsible for
+ * The {@link FeatureConstraintsEmpty} provides constraints of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsEnum.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsEnum.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
 import java.util.List;
 
 /**
- * The {@link FeatureConstraintsEnum} is responsible for
+ * The {@link FeatureConstraintsEnum} provides enum constraints of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsLength.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsLength.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureConstraintsLength} is responsible for
+ * The {@link FeatureConstraintsLength} provides length constraints of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsSchedule.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsSchedule.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
 import java.util.List;
 
 /**
- * The {@link FeatureConstraintsSchedule} is responsible for
+ * The {@link FeatureConstraintsSchedule} provides schedule constraints of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsSteppingDouble.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsSteppingDouble.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureConstraintsSteppingDouble} is responsible for
+ * The {@link FeatureConstraintsSteppingDouble} provides double stepping constraints of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsSteppingInteger.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureConstraintsSteppingInteger.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureConstraintsSteppingInteger} is responsible for
+ * The {@link FeatureConstraintsSteppingInteger} provides integer stepping constraints of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDataDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDataDTO.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
 import java.util.List;
 
 /**
- * The {@link FeatureDataDTO} is responsible for
+ * The {@link FeatureDataDTO} provides all data of a feature
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDay.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDay.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureDay} is responsible for
+ * The {@link FeatureDay} provides day of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefalutSetterParamsInteger.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefalutSetterParamsInteger.java
@@ -13,10 +13,12 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTargetTemperatureParams} is responsible for
+ * The {@link FeatureDefalutSetterParamsInteger} is responsible for
  *
  * @author Ronny Grun - Initial contribution
  */
-public class FeatureSetTargetTemperatureParams {
-    public FeatureDefalutSetterParamsInteger temperature;
+public class FeatureDefalutSetterParamsInteger {
+    Boolean required;
+    String type;
+    public FeatureConstraintsSteppingInteger constraints;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefaultCommands.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefaultCommands.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureDefaultCommands} is responsible for
+ * The {@link FeatureDefaultCommands} provides default command of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefaultSetterParamsDouble.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefaultSetterParamsDouble.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureDefaultSetterParamsDouble} is responsible for
+ * The {@link FeatureDefaultSetterParamsDouble} provides default parameters of double features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefaultSetterParamsDouble.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefaultSetterParamsDouble.java
@@ -13,10 +13,12 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTargetTemperatureParams} is responsible for
+ * The {@link FeatureDefaultSetterParamsDouble} is responsible for
  *
  * @author Ronny Grun - Initial contribution
  */
-public class FeatureSetTargetTemperatureParams {
-    public FeatureDefalutSetterParamsInteger temperature;
+public class FeatureDefaultSetterParamsDouble {
+    public Boolean required;
+    public String type;
+    public FeatureConstraintsSteppingDouble constraints;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefaultSetterParamsInteger.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDefaultSetterParamsInteger.java
@@ -13,11 +13,11 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureDefalutSetterParamsInteger} is responsible for
+ * The {@link FeatureDefaultSetterParamsInteger} provides default parameters of integer features
  *
  * @author Ronny Grun - Initial contribution
  */
-public class FeatureDefalutSetterParamsInteger {
+public class FeatureDefaultSetterParamsInteger {
     Boolean required;
     String type;
     public FeatureConstraintsSteppingInteger constraints;

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDouble.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureDouble.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureDouble} is responsible for
+ * The {@link FeatureDouble} provides values of double features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureEmptyParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureEmptyParams.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureEmptyParams} is responsible for
+ * The {@link FeatureEmptyParams} provides empty parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureEntriesWeekDays.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureEntriesWeekDays.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureEntriesWeekDays} is responsible for
+ * The {@link FeatureEntriesWeekDays} provides weekday entries of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureInteger.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureInteger.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureInteger} is responsible for
+ * The {@link FeatureInteger} provides integer value of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureListDouble.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureListDouble.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
 import java.util.List;
 
 /**
- * The {@link FeatureListDouble} is responsible for
+ * The {@link FeatureListDouble} provides list with double value of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureMode.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureMode.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureMode} is responsible for
+ * The {@link FeatureMode} provides modes of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureModeParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureModeParams.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureModeParams} is responsible for
+ * The {@link FeatureModeParams} provides mode parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureNewSchedule.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureNewSchedule.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureNewSchedule} is responsible for
+ * The {@link FeatureNewSchedule} provides new schedule of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureParamsName.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureParamsName.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureParamsName} is responsible for
+ * The {@link FeatureParamsName} provides name parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureProperties.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureProperties.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
 import java.util.ArrayList;
 
 /**
- * The {@link FeatureProperties} is responsible for
+ * The {@link FeatureProperties} provides properties of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureProperties.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureProperties.java
@@ -41,6 +41,13 @@ public class FeatureProperties {
     public FeatureString unit;
     public FeatureDouble hours;
     public FeatureInteger starts;
+    public FeatureInteger hoursLoadClassOne;
+    public FeatureInteger hoursLoadClassTwo;
+    public FeatureInteger hoursLoadClassThree;
+    public FeatureInteger hoursLoadClassFour;
+    public FeatureInteger hoursLoadClassFive;
+    public FeatureInteger min;
+    public FeatureInteger max;
 
     public ArrayList<String> getUsedEntries() {
         ArrayList<String> list = new ArrayList<String>();
@@ -107,6 +114,27 @@ public class FeatureProperties {
         }
         if (starts != null) {
             list.add("starts");
+        }
+        if (hoursLoadClassOne != null) {
+            list.add("hoursLoadClassOne");
+        }
+        if (hoursLoadClassOne != null) {
+            list.add("hoursLoadClassTwo");
+        }
+        if (hoursLoadClassOne != null) {
+            list.add("hoursLoadClassThree");
+        }
+        if (hoursLoadClassOne != null) {
+            list.add("hoursLoadClassFour");
+        }
+        if (hoursLoadClassOne != null) {
+            list.add("hoursLoadClassFive");
+        }
+        if (min != null) {
+            list.add("min");
+        }
+        if (max != null) {
+            list.add("max");
         }
 
         return list;

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSchedule.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSchedule.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSchedule} is responsible for
+ * The {@link FeatureSchedule} provides schedule of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureScheduleParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureScheduleParams.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureScheduleParams} is responsible for
+ * The {@link FeatureScheduleParams} provides schedule parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetCurve.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetCurve.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetCurve} is responsible for
+ * The {@link FeatureSetCurve} provides set curve of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetDate.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetDate.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetDate} is responsible for
+ * The {@link FeatureSetDate} provides set date of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHeatingCurve.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHeatingCurve.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetHeatingCurve} is responsible for
+ * The {@link FeatureSetHeatingCurve} provides set heatig curve of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresis.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresis.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetHysteresis} is responsible for
+ * The {@link FeatureSetHysteresis} provides set hysteresis of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresis.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresis.java
@@ -13,12 +13,13 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureDefalutSetterParams} is responsible for
+ * The {@link FeatureSetHysteresis} is responsible for
  *
  * @author Ronny Grun - Initial contribution
  */
-public class FeatureDefalutSetterParams {
-    Boolean required;
-    String type;
-    public FeatureConstraintsSteppingInteger constraints;
+public class FeatureSetHysteresis {
+    public String uri;
+    public String name;
+    public Boolean isExecutable;
+    public FeatureSetHeatingCurve params;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresisParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresisParams.java
@@ -13,10 +13,13 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTargetTemperatureParams} is responsible for
+ * The {@link FeatureSetHysteresisParams} is responsible for
  *
  * @author Ronny Grun - Initial contribution
  */
-public class FeatureSetTargetTemperatureParams {
-    public FeatureDefalutSetterParamsInteger temperature;
+public class FeatureSetHysteresisParams {
+    public String uri;
+    public String name;
+    public Boolean isExecutable;
+    public FeatureSetHysteresisParamsHysteresis params;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresisParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresisParams.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetHysteresisParams} is responsible for
+ * The {@link FeatureSetHysteresisParams} provides set hysteresis parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresisParamsHysteresis.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresisParamsHysteresis.java
@@ -13,10 +13,10 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTargetTemperatureParams} is responsible for
+ * The {@link FeatureSetHysteresisParamsHysteresis} is responsible for
  *
  * @author Ronny Grun - Initial contribution
  */
-public class FeatureSetTargetTemperatureParams {
-    public FeatureDefalutSetterParamsInteger temperature;
+public class FeatureSetHysteresisParamsHysteresis {
+    public FeatureDefaultSetterParamsDouble hysteresis;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresisParamsHysteresis.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetHysteresisParamsHysteresis.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetHysteresisParamsHysteresis} is responsible for
+ * The {@link FeatureSetHysteresisParamsHysteresis} provides hysteresis parameters features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetLevels.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetLevels.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetLevels} is responsible for
+ * The {@link FeatureSetLevels} provides set levels of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetLevels.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetLevels.java
@@ -13,10 +13,13 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTargetTemperatureParams} is responsible for
+ * The {@link FeatureSetLevels} is responsible for
  *
  * @author Ronny Grun - Initial contribution
  */
-public class FeatureSetTargetTemperatureParams {
-    public FeatureDefalutSetterParamsInteger temperature;
+public class FeatureSetLevels {
+    public String uri;
+    public String name;
+    public Boolean isExecutable;
+    public FeatureSetLevelsParams params;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetLevelsParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetLevelsParams.java
@@ -13,11 +13,11 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetLevelsParams} is responsible for
+ * The {@link FeatureSetLevelsParams} provides levels parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */
 public class FeatureSetLevelsParams {
-    public FeatureDefalutSetterParamsInteger minTemperature;
-    public FeatureDefalutSetterParamsInteger maxTemperature;
+    public FeatureDefaultSetterParamsInteger minTemperature;
+    public FeatureDefaultSetterParamsInteger maxTemperature;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetLevelsParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetLevelsParams.java
@@ -13,10 +13,11 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTargetTemperatureParams} is responsible for
+ * The {@link FeatureSetLevelsParams} is responsible for
  *
  * @author Ronny Grun - Initial contribution
  */
-public class FeatureSetTargetTemperatureParams {
-    public FeatureDefalutSetterParamsInteger temperature;
+public class FeatureSetLevelsParams {
+    public FeatureDefalutSetterParamsInteger minTemperature;
+    public FeatureDefalutSetterParamsInteger maxTemperature;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetMode.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetMode.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetMode} is responsible for
+ * The {@link FeatureSetMode} provides set mode of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetName.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetName.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetName} is responsible for
+ * The {@link FeatureSetName} provides set name of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetNameParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetNameParams.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetNameParams} is responsible for
+ * The {@link FeatureSetNameParams} provides set name parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetSchedule.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetSchedule.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetSchedule} is responsible for
+ * The {@link FeatureSetSchedule} provides set schedule of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetScheduleParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetScheduleParams.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetScheduleParams} is responsible for
+ * The {@link FeatureSetScheduleParams} provides set schedule parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetTargetTemperature.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetTargetTemperature.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTargetTemperature} is responsible for
+ * The {@link FeatureSetTargetTemperature} provides set target temperature of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetTargetTemperatureParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetTargetTemperatureParams.java
@@ -13,10 +13,10 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTargetTemperatureParams} is responsible for
+ * The {@link FeatureSetTargetTemperatureParams} provides set target temperature parameters of features
  *
  * @author Ronny Grun - Initial contribution
  */
 public class FeatureSetTargetTemperatureParams {
-    public FeatureDefalutSetterParamsInteger temperature;
+    public FeatureDefaultSetterParamsInteger temperature;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetTemperature.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSetTemperature.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSetTemperature} is responsible for
+ * The {@link FeatureSetTemperature} provides set temperature of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureShift.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureShift.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureShift} is responsible for
+ * The {@link FeatureShift} provides shift of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSlope.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureSlope.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureSlope} is responsible for
+ * The {@link FeatureSlope} provides slope of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureString.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureString.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureString} is responsible for
+ * The {@link FeatureString} provides string value of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureTargetTemperatureParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureTargetTemperatureParams.java
@@ -13,10 +13,10 @@
 package org.smarthomej.binding.viessmann.internal.dto.features;
 
 /**
- * The {@link FeatureTargetTemperatureParams} is responsible for
+ * The {@link FeatureTargetTemperatureParams} provides parameters of target temperature features
  *
  * @author Ronny Grun - Initial contribution
  */
 public class FeatureTargetTemperatureParams {
-    public FeatureDefalutSetterParamsInteger targetTemperature;
+    public FeatureDefaultSetterParamsInteger targetTemperature;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureTargetTemperatureParams.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureTargetTemperatureParams.java
@@ -18,5 +18,5 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
  * @author Ronny Grun - Initial contribution
  */
 public class FeatureTargetTemperatureParams {
-    public FeatureDefalutSetterParams targetTemperature;
+    public FeatureDefalutSetterParamsInteger targetTemperature;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureWeekDays.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeatureWeekDays.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
 import java.util.List;
 
 /**
- * The {@link FeatureWeekDays} is responsible for
+ * The {@link FeatureWeekDays} provides weekdays for feature
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeaturesDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/features/FeaturesDTO.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.features;
 import java.util.List;
 
 /**
- * The {@link FeaturesDTO} is responsible for
+ * The {@link FeaturesDTO} provides a list of features
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Address.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Address.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.installation;
 
 /**
- * The {@link Address} is responsible for
+ * The {@link Address} provides address data of the installation
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Cursor.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Cursor.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.installation;
 
 /**
- * The {@link Cursor} is responsible for
+ * The {@link Cursor} provides the cursor of the installation
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Data.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Data.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.installation;
 import java.util.List;
 
 /**
- * * The {@link Data} is responsible for
+ * * The {@link Data} provides all data of the installation
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Device.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Device.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.installation;
 import java.util.List;
 
 /**
- * The {@link Device} is responsible for
+ * The {@link Device} provides a device on the installation
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Gateway.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Gateway.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.installation;
 import java.util.List;
 
 /**
- * The {@link Gateway} is responsible for
+ * The {@link Gateway} provides all data of the gateway
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Geolocation.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/Geolocation.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.installation;
 
 /**
- * The {@link Geolocation} is responsible for
+ * The {@link Geolocation} provides the geolocation of the installation
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/InstallationDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/installation/InstallationDTO.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.installation;
 import java.util.List;
 
 /**
- * The {@link InstallationDTO} is responsible for
+ * The {@link InstallationDTO} provides all data of the installation
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/oauth/AuthorizeResponseDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/oauth/AuthorizeResponseDTO.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.oauth;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * The {@link AuthorizeResponseDTO} is responsible for
+ * The {@link AuthorizeResponseDTO} provides the authorize response
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/oauth/TokenResponseDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/oauth/TokenResponseDTO.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.oauth;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * The {@link TokenResponseDTO} is responsible for
+ * The {@link TokenResponseDTO} provides the token response
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/schedule/DaySchedule.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/schedule/DaySchedule.java
@@ -13,7 +13,7 @@
 package org.smarthomej.binding.viessmann.internal.dto.schedule;
 
 /**
- * The {@link DaySchedule} is responsible for
+ * The {@link DaySchedule} provides the schedule of each day
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/schedule/ScheduleDTO.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/dto/schedule/ScheduleDTO.java
@@ -15,7 +15,7 @@ package org.smarthomej.binding.viessmann.internal.dto.schedule;
 import java.util.List;
 
 /**
- * The {@link ScheduleDTO} is responsible for
+ * The {@link ScheduleDTO} provides the schedule of a scheduled feature
  *
  * @author Ronny Grun - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
@@ -140,13 +140,13 @@ public class DeviceHandler extends ViessmannThingHandler {
                                 thing.getChannel(channelUID.getId()));
                     } else if (command instanceof QuantityType<?>) {
                         QuantityType<?> value = (QuantityType<?>) command;
-                        Double f = value.doubleValue();
-                        String s = f.toString();
+                        double f = value.doubleValue();
+                        // String s = f.toString();
                         for (String str : com) {
                             if (str.contains("Temperature") || str.contains("setHysteresis") || str.contains("setMin")
                                     || str.contains("setMax")) {
                                 uri = prop.get(str + "Uri");
-                                param = "{\"" + prop.get(str + "Params") + "\":" + s + "}";
+                                param = "{\"" + prop.get(str + "Params") + "\":" + f + "}";
                                 break;
                             }
                         }
@@ -428,6 +428,10 @@ public class DeviceHandler extends ViessmannThingHandler {
                                 case "decimal":
                                 case "number":
                                 case "temperature":
+                                case "percent":
+                                case "minute":
+                                case "hours":
+                                case "kelvin":
                                     if (unit == null) {
                                         DecimalType state = DecimalType.valueOf(msg.getValue());
                                         updateState(msg.getChannelId(), state);
@@ -435,13 +439,6 @@ public class DeviceHandler extends ViessmannThingHandler {
                                         updateState(msg.getChannelId(),
                                                 new QuantityType<>(msg.getValue() + " " + unit));
                                     }
-                                    break;
-                                case "percent":
-                                case "minute":
-                                case "hours":
-                                case "kelvin":
-                                    updateState(msg.getChannelId(),
-                                            new QuantityType<>(Double.valueOf(msg.getValue()) + " " + unit));
                                     break;
                                 case "boolean":
                                     OnOffType state = bool ? OnOffType.ON : OnOffType.OFF;

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
@@ -376,7 +376,7 @@ public class DeviceHandler extends ViessmannThingHandler {
                                     unit = UNIT_MAP.get(viUnit);
                                     if (unit == null) {
                                         logger.warn(
-                                                "Unknown unit. Could not parse the unit: {} of the Feature: {} Please report an issue on github",
+                                                "Unknown unit. Could not parse unit: {} of Feature: {} - Please open an issue on GitHub.",
                                                 viUnit, featureDataDTO.feature);
                                     }
                                 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
@@ -140,10 +140,11 @@ public class DeviceHandler extends ViessmannThingHandler {
                                 thing.getChannel(channelUID.getId()));
                     } else if (command instanceof QuantityType<?>) {
                         QuantityType<?> value = (QuantityType<?>) command;
-                        Integer f = value.intValue();
+                        Double f = value.doubleValue();
                         String s = f.toString();
                         for (String str : com) {
-                            if (str.contains("Temperature")) {
+                            if (str.contains("Temperature") || str.contains("setHysteresis") || str.contains("setMin")
+                                    || str.contains("setMax")) {
                                 uri = prop.get(str + "Uri");
                                 param = "{\"" + prop.get(str + "Params") + "\":" + s + "}";
                                 break;
@@ -211,7 +212,7 @@ public class DeviceHandler extends ViessmannThingHandler {
                             viUnit = prop.value.unit;
                             if ("celsius".equals(viUnit)) {
                                 typeEntry = "temperature";
-                            } else if ("percent".equals(viUnit) || "minute".equals(viUnit)) {
+                            } else if ("percent".equals(viUnit) || "minute".equals(viUnit) || "kelvin".equals(viUnit)) {
                                 typeEntry = viUnit;
                             } else {
                                 typeEntry = prop.value.type;
@@ -319,7 +320,42 @@ public class DeviceHandler extends ViessmannThingHandler {
                         case "hours":
                             typeEntry = entry;
                             valueEntry = prop.hours.value.toString();
-                            viUnit = prop.hours.unit;
+                            viUnit = "hour";
+                            break;
+                        case "hoursLoadClassOne":
+                            typeEntry = "hours";
+                            valueEntry = prop.hoursLoadClassOne.value.toString();
+                            viUnit = "hour";
+                            break;
+                        case "hoursLoadClassTwo":
+                            typeEntry = "hours";
+                            valueEntry = prop.hoursLoadClassTwo.value.toString();
+                            viUnit = "hour";
+                            break;
+                        case "hoursLoadClassThree":
+                            typeEntry = "hours";
+                            valueEntry = prop.hoursLoadClassThree.value.toString();
+                            viUnit = "hour";
+                            break;
+                        case "hoursLoadClassFour":
+                            typeEntry = "hours";
+                            valueEntry = prop.hoursLoadClassFour.value.toString();
+                            viUnit = "hour";
+                            break;
+                        case "hoursLoadClassFive":
+                            typeEntry = "hours";
+                            valueEntry = prop.hoursLoadClassFive.value.toString();
+                            viUnit = "hour";
+                            break;
+                        case "min":
+                            typeEntry = prop.min.type;
+                            valueEntry = prop.min.value.toString();
+                            viUnit = prop.min.unit;
+                            break;
+                        case "max":
+                            typeEntry = prop.max.type;
+                            valueEntry = prop.max.value.toString();
+                            viUnit = prop.max.unit;
                             break;
                         default:
                             break;
@@ -403,6 +439,7 @@ public class DeviceHandler extends ViessmannThingHandler {
                                 case "percent":
                                 case "minute":
                                 case "hours":
+                                case "kelvin":
                                     updateState(msg.getChannelId(),
                                             new QuantityType<>(Double.valueOf(msg.getValue()) + " " + unit));
                                     break;
@@ -561,11 +598,27 @@ public class DeviceHandler extends ViessmannThingHandler {
                             prop.put("unscheduleUri", commands.unschedule.uri);
                             prop.put("unscheduleParams", "{}");
                             break;
-                        case "setTargetTemperature":
-                            channelType = "type-setTargetTemperature";
-                            prop.put("setTargetTemperatureUri", commands.setTargetTemperature.uri);
-                            prop.put("command", "setTargetTemperature");
-                            prop.put("setTargetTemperatureParams", "temperature");
+                        case "setMin":
+                            if (msg.getSuffix().contains("min")) {
+                                channelType = "type-setMin";
+                                prop.put("setMinUri", commands.setMin.uri);
+                                prop.put("command", "setMin");
+                                prop.put("setMinParams", "temperature");
+                            }
+                            break;
+                        case "setMax":
+                            if (msg.getSuffix().contains("max")) {
+                                channelType = "type-setMax";
+                                prop.put("setMaxUri", commands.setMax.uri);
+                                prop.put("command", "setMax");
+                                prop.put("setMaxParams", "temperature");
+                            }
+                            break;
+                        case "setHysteresis":
+                            channelType = "type-setTargetHysteresis";
+                            prop.put("setHysteresisUri", commands.setHysteresis.uri);
+                            prop.put("command", "setHysteresis");
+                            prop.put("setHysteresisParams", "hysteresis");
                             break;
                         default:
                             break;

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -172,6 +172,14 @@
 		</state>
 	</channel-type>
 
+	<channel-type id="type-liter">
+		<item-type>Number:Time</item-type>
+		<label>Liter</label>
+		<category>Number</category>
+		<state pattern="%d %unit%" readOnly="true">
+		</state>
+	</channel-type>
+
 	<channel-type id="type-string">
 		<item-type>String</item-type>
 		<label>String</label>

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -71,7 +71,7 @@
 		</supported-bridge-type-refs>
 		<label>Viessmann Device</label>
 		<properties>
-			<property name="thingTypeVersion">1</property>
+			<property name="thingTypeVersion">2</property>
 		</properties>
 		<representation-property>deviceId</representation-property>
 		<config-description>
@@ -99,9 +99,30 @@
 
 	<channel-type id="type-setTargetTemperature">
 		<item-type>Number:Temperature</item-type>
-		<label>Set terget temperature</label>
+		<label>Set target temperature</label>
 		<category>Temperature</category>
 		<state min="10" max="60" step="1" pattern="%d %unit%" readOnly="false"/>
+	</channel-type>
+
+	<channel-type id="type-setTargetHysteresis">
+		<item-type>Number:Temperature</item-type>
+		<label>Set target hysteresis</label>
+		<category>Temperature</category>
+		<state min="1" max="10" step="0.5" pattern="%.1f %unit%" readOnly="false"/>
+	</channel-type>
+
+	<channel-type id="type-setMin">
+		<item-type>Number:Temperature</item-type>
+		<label>Set target Temp. min</label>
+		<category>Temperature</category>
+		<state min="1" max="30" step="1" pattern="%d %unit%" readOnly="false"/>
+	</channel-type>
+
+	<channel-type id="type-setMax">
+		<item-type>Number:Temperature</item-type>
+		<label>Set target Temp. max</label>
+		<category>Temperature</category>
+		<state min="10" max="70" step="1" pattern="%d %unit%" readOnly="false"/>
 	</channel-type>
 
 	<channel-type id="type-energy">

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/update/device.update
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/update/device.update
@@ -25,4 +25,4 @@
 1;REMOVE_CHANNEL;heatingSensorsTemperatureOutside
 1;REMOVE_CHANNEL;heatingSolarSensorsTemperatureDhw
 1;REMOVE_CHANNEL;heatingSolarSensorsTemperatureCollector
-1;REMOVE_CHANNEL;heatingDhwTemperatureHysteresis
+2;REMOVE_CHANNEL;heatingDhwTemperatureHysteresis

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/update/device.update
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/update/device.update
@@ -25,3 +25,4 @@
 1;REMOVE_CHANNEL;heatingSensorsTemperatureOutside
 1;REMOVE_CHANNEL;heatingSolarSensorsTemperatureDhw
 1;REMOVE_CHANNEL;heatingSolarSensorsTemperatureCollector
+1;REMOVE_CHANNEL;heatingDhwTemperatureHysteresis


### PR DESCRIPTION
This PR adds support for Vitocal heat pump and fixes the bug with different naming of unit from the API.
It was reported on the openhab community here: 
[https://community.openhab.org/t/binding-request-viessmann-api-vicare-not-vitotronic/117275/19](https://community.openhab.org/t/binding-request-viessmann-api-vicare-not-vitotronic/117275/19)