### PR TITLE
[tuya] fix protocol 3.1 devices not going ONLINE

### DIFF
--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -285,13 +285,11 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
 
         updateStatus(ThingStatus.UNKNOWN);
         TuyaDevice tuyaDevice = this.tuyaDevice;
-        if (tuyaDevice == null) {
-            tuyaDevice = new TuyaDevice(gson, this, eventLoopGroup, configuration.deviceId,
-                    configuration.localKey.getBytes(StandardCharsets.UTF_8), deviceInfo.ip, deviceInfo.protocolVersion);
-            this.tuyaDevice = tuyaDevice;
-        } else {
-            tuyaDevice.setAddress(deviceInfo.ip);
+        if (tuyaDevice != null) {
+            tuyaDevice.dispose();
         }
+        this.tuyaDevice = new TuyaDevice(gson, this, eventLoopGroup, configuration.deviceId,
+                configuration.localKey.getBytes(StandardCharsets.UTF_8), deviceInfo.ip, deviceInfo.protocolVersion);
     }
 
     private void addChannels(Map<String, SchemaDp> schema) {

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/TuyaDevice.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/TuyaDevice.java
@@ -55,7 +55,7 @@ public class TuyaDevice implements ChannelFutureListener {
     private final DeviceStatusListener deviceStatusListener;
     private final String deviceId;
 
-    private String address;
+    private final String address;
     private @Nullable Channel channel;
 
     public TuyaDevice(Gson gson, DeviceStatusListener deviceStatusListener, EventLoopGroup eventLoopGroup,
@@ -91,11 +91,6 @@ public class TuyaDevice implements ChannelFutureListener {
             channel.pipeline().fireUserEventTriggered(new UserEventHandler.DisposeEvent());
             this.channel = null;
         }
-    }
-
-    public void setAddress(String address) {
-        this.address = address;
-        disconnect();
     }
 
     public void set(Map<Integer, Object> command) {

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/dto/DiscoveryMessage.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/dto/DiscoveryMessage.java
@@ -27,14 +27,17 @@ public class DiscoveryMessage {
     @SerializedName("gwId")
     public String deviceId = "";
     public int active = 0;
-    public int ablilty = 0;
+    @SerializedName(value = "ability", alternate = { "ablilty" })
+    public int ability = 0;
+    public int mode = 0;
     public boolean encrypt = true;
     public String productKey = "";
     public String version = "";
 
     @Override
     public String toString() {
-        return "Discovery{ip='" + ip + "', deviceId='" + deviceId + "', active=" + active + ", ablilty=" + ablilty
-                + ", encrypt=" + encrypt + ", productKey='" + productKey + "', version='" + version + "'}";
+        return "DiscoveryMessage{ip='" + ip + "', deviceId='" + deviceId + "', active=" + active + ", ability="
+                + ability + ", mode=" + mode + ", encrypt=" + encrypt + ", productKey='" + productKey + "', version='"
+                + version + "'}";
     }
 }

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/dto/DiscoveryMessage.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/dto/DiscoveryMessage.java
@@ -17,7 +17,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * The {@link DiscoveryMessage} is a
+ * The {@link DiscoveryMessage} represents the UDP discovery messages sent by Tuya devices
  *
  * @author Jan N. Klug - Initial contribution
  */

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/handlers/DiscoveryMessageHandler.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/handlers/DiscoveryMessageHandler.java
@@ -43,7 +43,8 @@ public class DiscoveryMessageHandler extends ChannelDuplexHandler {
     @Override
     public void channelRead(@NonNullByDefault({}) ChannelHandlerContext ctx, @NonNullByDefault({}) Object msg)
             throws Exception {
-        if (msg instanceof MessageWrapper<?> && CommandType.UDP_NEW.equals(((MessageWrapper<?>) msg).commandType)) {
+        if (msg instanceof MessageWrapper<?> && (CommandType.UDP_NEW.equals(((MessageWrapper<?>) msg).commandType)
+                || CommandType.UDP.equals((((MessageWrapper<?>) msg).commandType)))) {
             @SuppressWarnings("unchecked")
             DiscoveryMessage discoveryMessage = ((MessageWrapper<DiscoveryMessage>) msg).content;
             DeviceInfo deviceInfo = new DeviceInfo(discoveryMessage.ip, discoveryMessage.version);

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/handlers/TuyaDecoder.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/handlers/TuyaDecoder.java
@@ -137,12 +137,16 @@ public class TuyaDecoder extends ByteToMessageDecoder {
         MessageWrapper<?> m;
         if (CommandType.UDP.equals(commandType)) {
             // UDP is unencrpyted
-            m = new MessageWrapper<>(commandType, new String(payload));
+            m = new MessageWrapper<>(commandType,
+                    Objects.requireNonNull(gson.fromJson(new String(payload), DiscoveryMessage.class)));
         } else {
             String decodedMessage = CryptoUtil.decryptAesEcb(payload, key);
             if (decodedMessage == null) {
                 return;
             }
+            logger.trace("{}/{}: Decoded raw payload: {}", deviceId,
+                    Objects.requireNonNullElse(ctx.channel().remoteAddress(), ""), decodedMessage);
+
             if (CommandType.STATUS.equals(commandType) || CommandType.DP_QUERY.equals(commandType)) {
                 Type type = TypeToken.getParameterized(TcpPayload.class, INTEGER_OBJECT_MAP_TYPE).getType();
                 m = new MessageWrapper<>(commandType,


### PR DESCRIPTION
Fixes #303 

UDP type messages were ignored instead of passing them to the thing handler. Also unencrypted messages were not properly converted.