### PR TITLE
[telenot] add handling for unused contact

### DIFF
--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
@@ -301,7 +301,8 @@ public abstract class TelenotBridgeHandler extends BaseBridgeHandler {
                         case NOT_USED_CONTACT:
                             logger.debug("Received {} MsgType | hexString: {}", msgType, message);
                             if (!usedInputContact.isEmpty()) {
-                                logger.info("Contact {} not used. Discovery will skip this contact.", usedInputContact.get(0));
+                                logger.info("Contact {} not used. Discovery will skip this contact.",
+                                        usedInputContact.get(0));
                                 usedInputContact.remove(0);
                             }
                             sendTelenotCommand(TelenotCommand.confirmACK());

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
@@ -301,7 +301,7 @@ public abstract class TelenotBridgeHandler extends BaseBridgeHandler {
                         case NOT_USED_CONTACT:
                             logger.debug("Received {} MsgType | hexString: {}", msgType, message);
                             if (!usedInputContact.isEmpty()) {
-                                logger.warn("Contact {} not used", usedInputContact.get(0));
+                                logger.info("Contact {} not used. Discovery will skip this contact.", usedInputContact.get(0));
                                 usedInputContact.remove(0);
                             }
                             sendTelenotCommand(TelenotCommand.confirmACK());

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/handler/TelenotBridgeHandler.java
@@ -298,6 +298,16 @@ public abstract class TelenotBridgeHandler extends BaseBridgeHandler {
                             TelenotThingHandler.readyToSendData.set(true);
                             logger.trace("Ready to send data");
                             break;
+                        case NOT_USED_CONTACT:
+                            logger.debug("Received {} MsgType | hexString: {}", msgType, message);
+                            if (!usedInputContact.isEmpty()) {
+                                logger.warn("Contact {} not used", usedInputContact.get(0));
+                                usedInputContact.remove(0);
+                            }
+                            sendTelenotCommand(TelenotCommand.confirmACK());
+                            TelenotThingHandler.readyToSendData.set(true);
+                            logger.trace("Ready to send data");
+                            break;
                         default:
                             break;
                     }

--- a/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/TelenotMsgType.java
+++ b/bundles/org.smarthomej.binding.telenot/src/main/java/org/smarthomej/binding/telenot/internal/protocol/TelenotMsgType.java
@@ -47,7 +47,8 @@ public enum TelenotMsgType {
     USED_SB_CONTACTS_INFO,
     USED_MB_CONTACTS_INFO,
     UNKNOWN,
-    INVALID;
+    INVALID,
+    NOT_USED_CONTACT;
 
     /** hash map from protocol message heading to type */
     private static final Map<String, TelenotMsgType> START_TO_MSG_TYPE = Map.of("682C2C687302050201001001",
@@ -55,7 +56,7 @@ public enum TelenotMsgType {
             "681A1A687302050200001501", TelenotMsgType.POWER_OUTAGE, "681A1A687302050200001301",
             TelenotMsgType.OPTICAL_FLASHER_MALFUNCTION, "681A1A687302050200001101", TelenotMsgType.HORN_1_MALFUNCTION,
             "681A1A687302050200001201", TelenotMsgType.HORN_2_MALFUNCTION, "681A1A687302050200001701",
-            TelenotMsgType.COM_FAULT);
+            TelenotMsgType.COM_FAULT, "68060668730202110019A116", TelenotMsgType.NOT_USED_CONTACT);
 
     /**
      * Extract message type from message. Relies on static map startToMsgType.


### PR DESCRIPTION
Some installations discover contacts that are unused. In this case, the discovery runs in a loop.

Signed-off-by: Ronny Grun <ronny.grun@t-online.de>