### PR TITLE
[amazonechocontrol] fix radioStationId channel

### DIFF
--- a/bundles/org.smarthomej.binding.amazonechocontrol/README.md
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/README.md
@@ -152,8 +152,8 @@ You will find the serial number in the Alexa app or on the webpage YOUR_OPENHAB/
 | bluetoothMAC              | String      | R/W         | echo, echoshow, echospot      | Bluetooth device MAC. Used to connect to a specific device or disconnect if an empty string was provided                                                                                                                                |
 | bluetooth                 | Switch      | R/W         | echo, echoshow, echospot      | Connect/Disconnect to the last used bluetooth device (works after a bluetooth connection was established after the openHAB start)                                                                                                       |
 | bluetoothDeviceName       | String      | R           | echo, echoshow, echospot      | User friendly name of the connected bluetooth device                                                                                                                                                                                    |
-| radioStationId (*)        | String      | R/W         | echo, echoshow, echospot, wha | Start playing of a TuneIn radio station by specifying its id or stops playing if an empty string was provided                                                                                                                           |
-| radio (*)                 | Switch      | R/W         | echo, echoshow, echospot, wha | Start playing of the last used TuneIn radio station (works after the radio station started after the openHAB start)                                                                                                                     |
+| radioStationId            | String      | R/W         | echo, echoshow, echospot, wha | Start playing of a TuneIn radio station by specifying its id or stops playing if an empty string was provided                                                                                                                           |
+| radio                     | Switch      | R/W         | echo, echoshow, echospot, wha | Start playing of the last used TuneIn radio station (works after the radio station started after the openHAB start)                                                                                                                     |
 | amazonMusicTrackId (*)    | String      | R/W         | echo, echoshow, echospot, wha | Start playing of an Amazon Music track by its id or stops playing if an empty string was provided                                                                                                                                       |
 | amazonMusicPlayListId (*) | String      | W           | echo, echoshow, echospot, wha | Write Only! Start playing of an Amazon Music playlist by specifying its id or stops playing if an empty string was provided.                                                                                                            |
 | amazonMusic (*)           | Switch      | R/W         | echo, echoshow, echospot, wha | Start playing of the last used Amazon Music song (works after at least one song was started after the openHAB start)                                                                                                                    |
@@ -185,7 +185,7 @@ You will find the serial number in the Alexa app or on the webpage YOUR_OPENHAB/
 
 **Attention:** Channels marked with (*) are deprecated and will be removed in the future.
 Amazon already started to remove some of that functionality.
-You can use the `textCommand` channel with a value of `Play Radio XYZ on TuneIn` or `Play playlist CrazyMusic on AmazonMusic` instead.
+You can use the `textCommand` channel with a value of `Play playlist CrazyMusic on AmazonMusic` instead.
 
 ## Advanced Feature Technically Experienced Users
 

--- a/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/connection/Connection.java
+++ b/bundles/org.smarthomej.binding.amazonechocontrol/src/main/java/org/smarthomej/binding/amazonechocontrol/internal/connection/Connection.java
@@ -1102,12 +1102,12 @@ public class Connection {
         if (stationId == null || stationId.isEmpty()) {
             command(device, "{\"type\":\"PauseCommand\"}");
         } else {
-            makeRequest("POST",
-                    alexaServer + "/api/tunein/queue-and-play?deviceSerialNumber=" + device.serialNumber
-                            + "&deviceType=" + device.deviceType + "&guideId=" + stationId
-                            + "&contentType=station&callSign=&mediaOwnerCustomerId="
-                            + getCustomerId(device.deviceOwnerCustomerId),
-                    "", true, true, Map.of(), 0);
+            String content = "[\"music/tuneIn/stationId\",\"" + stationId + "\"]|{\"previousPageId\":null}";
+            String contentToken = new String(
+                    Base64.getEncoder().encode(Base64.getEncoder().encode(content.getBytes(StandardCharsets.UTF_8))));
+            String body = "{\"contentToken\":\"music:" + contentToken + "\"}";
+            makeRequest("PUT", alexaServer + "/api/entertainment/v1/player/queue?deviceSerialNumber="
+                    + device.serialNumber + "&deviceType=" + device.deviceType, body, true, true, Map.of(), 0);
         }
     }
 


### PR DESCRIPTION
Fixes the not working TuneIn radio channels. This is necessary due to changed API on server-side.

Signed-off-by: Jan N. Klug <github@klug.nrw>