### PR TITLE
[tuya] Fix a typo on SilentMode

### DIFF
--- a/bundles/org.smarthomej.binding.tuya/src/main/resources/schema.json
+++ b/bundles/org.smarthomej.binding.tuya/src/main/resources/schema.json
@@ -21575,7 +21575,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -23364,7 +23364,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -24148,7 +24148,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -24676,7 +24676,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -49598,7 +49598,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -60662,7 +60662,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},


### PR DESCRIPTION
This is a simple typo correction. HOWEVER, I think this channel, at least on my heat pump, has the opposite meaning. Instead of "Silent Mode", it should be called "Boost".

When it's ON, it goes full power 100% which is the opposite of silent. When it's OFF, it limits the maximum power to 80% to make it quieter.

Maybe on some other models it works for "Silent mode" / night mode