### PR TITLE
[knx] Fix all writes blocked

### DIFF
--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/DeviceThingHandler.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/DeviceThingHandler.java
@@ -222,7 +222,7 @@ public class DeviceThingHandler extends BaseThingHandler implements GroupAddress
                             // always remember, otherwise we might send an old state
                             groupAddressesRespondingSpec.put(destination, commandSpec);
                         }
-                        if (groupAddressesWriteBlocked.get(destination) == null) {
+                        if (groupAddressesWriteBlocked.get(destination) != null) {
                             logger.debug("Write to {} blocked for 1s/one call after read.", destination);
                             groupAddressesWriteBlocked.invalidate(destination);
                         } else {


### PR DESCRIPTION
Reported on Facebook. I have removed 3.2.11 of the knx-binding from the addon-service and replaced it with 3.2.10 for the time being.

Signed-off-by: Jan N. Klug <github@klug.nrw>