### PR TITLE
[knx] Fix DPT 251.600 decoding

### DIFF
--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/ValueDecoder.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/dpt/ValueDecoder.java
@@ -70,7 +70,7 @@ public class ValueDecoder {
     private static final Pattern RGB_PATTERN = Pattern.compile("r:(?<r>\\d+) g:(?<g>\\d+) b:(?<b>\\d+)");
     // RGBW: "100 27 25 12 %", value range: 0-100, invalid values: "-"
     private static final Pattern RGBW_PATTERN = Pattern
-            .compile("(?:(?<r>\\d+)|-)\\s(?:(?<g>\\d+)|-)\\s(?:(?<b>\\d+)|-)\\s(?:(?<w>\\d+)|-)\\s%");
+            .compile("(?:(?<r>[\\d,.]+)|-)\\s(?:(?<g>[\\d,.]+)|-)\\s(?:(?<b>[\\d,.]+)|-)\\s(?:(?<w>[\\d,.]+)|-)\\s%");
     // xyY: "(0,123 0,123) 56 %", value range 0-1 for xy (comma as decimal point), 0-100 for Y, invalid values omitted
     private static final Pattern XYY_PATTERN = Pattern
             .compile("(?:\\((?<x>\\d+(?:,\\d+)?) (?<y>\\d+(?:,\\d+)?)\\))?\\s*(?:(?<Y>\\d+(?:,\\d+)?)\\s%)?");
@@ -321,14 +321,14 @@ public class ValueDecoder {
 
             if (rString != null && gString != null && bString != null && HSBType.class.equals(preferredType)) {
                 // does not support PercentType and r,g,b valid -> HSBType
-                int r = coerceToRange((int) (Integer.parseInt(rString) * 2.55), 0, 255);
-                int g = coerceToRange((int) (Integer.parseInt(gString) * 2.55), 0, 255);
-                int b = coerceToRange((int) (Integer.parseInt(bString) * 2.55), 0, 255);
+                int r = coerceToRange((int) (Double.parseDouble(rString.replace(",", ".")) * 2.55), 0, 255);
+                int g = coerceToRange((int) (Double.parseDouble(gString.replace(",", ".")) * 2.55), 0, 255);
+                int b = coerceToRange((int) (Double.parseDouble(bString.replace(",", ".")) * 2.55), 0, 255);
 
                 return HSBType.fromRGB(r, g, b);
             } else if (wString != null && PercentType.class.equals(preferredType)) {
                 // does support PercentType and w valid -> PercentType
-                int w = Integer.parseInt(wString);
+                BigDecimal w = new BigDecimal(wString.replace(",", "."));
 
                 return new PercentType(w);
             }

--- a/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/DPTTest.java
+++ b/bundles/org.smarthomej.binding.knx/src/test/java/org/smarthomej/binding/knx/internal/dpt/DPTTest.java
@@ -16,7 +16,6 @@ package org.smarthomej.binding.knx.internal.dpt;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -75,10 +74,21 @@ public class DPTTest {
         HSBType hsbType = (HSBType) ValueDecoder.decode("232.60000", data, HSBType.class);
 
         Assertions.assertNotNull(hsbType);
-        Objects.requireNonNull(hsbType);
         assertEquals(173.6, hsbType.getHue().doubleValue(), 0.1);
         assertEquals(17.6, hsbType.getSaturation().doubleValue(), 0.1);
         assertEquals(26.3, hsbType.getBrightness().doubleValue(), 0.1);
+    }
+
+    @Test
+    public void dpt252EncoderTest() {
+        // input data
+        byte[] data = new byte[] { 0x26, 0x2b, 0x31, 0x00, 0x00, 0x0e };
+        HSBType hsbType = (HSBType) ValueDecoder.decode("251.600", data, HSBType.class);
+
+        assertNotNull(hsbType);
+        assertEquals(207, hsbType.getHue().doubleValue(), 0.1);
+        assertEquals(22, hsbType.getSaturation().doubleValue(), 0.1);
+        assertEquals(18, hsbType.getBrightness().doubleValue(), 0.1);
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Some values result in fractional values for RGBW values. This was not properly parsed by the binding.

Reported in private communication.

Signed-off-by: Jan N. Klug <github@klug.nrw>