### PR TITLE
[javarule] Fix NPE in ScriptEngine when ScriptDependencyListener not available

### DIFF
--- a/bundles/org.smarthomej.automation.javarule/src/main/java/org/smarthomej/automation/javarule/internal/script/JavaRuleScriptEngine.java
+++ b/bundles/org.smarthomej.automation.javarule/src/main/java/org/smarthomej/automation/javarule/internal/script/JavaRuleScriptEngine.java
@@ -58,7 +58,11 @@ public class JavaRuleScriptEngine extends JavaScriptEngine implements Invocable 
     public @Nullable Object eval(@Nullable String script, @Nullable Bindings bindings) throws ScriptException {
         if (bindings != null) {
             ScriptDependencyListener depListener = (ScriptDependencyListener) bindings.get("oh.dependency-listener");
-            depListener.accept(JAVARULE_DEPENDENCY_JAR.toString());
+            if (depListener != null) {
+                depListener.accept(JAVARULE_DEPENDENCY_JAR.toString());
+            } else {
+                logger.warn("Could not get script dependency listener, dependency tracking might fail.");
+            }
         }
 
         JavaRuleCompiledScript compiledScript = (JavaRuleCompiledScript) this.compile(script);


### PR DESCRIPTION
Reported in private mail. It is still unclear why the `ScriptDependencyListener` is not in the bindings, but at least the NPE will be avoided.

Signed-off-by: Jan N. Klug <github@klug.nrw>