### PR TITLE
[transform.math] Fix MathContext in division

### DIFF
--- a/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/transform/math/internal/DivideTransformationService.java
+++ b/bundles/org.smarthomej.transform.math/src/main/java/org/smarthomej/transform/math/internal/DivideTransformationService.java
@@ -13,6 +13,7 @@
 package org.smarthomej.transform.math.internal;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.transform.TransformationService;
@@ -29,6 +30,6 @@ public class DivideTransformationService extends AbstractMathTransformationServi
 
     @Override
     BigDecimal performCalculation(BigDecimal source, BigDecimal value) {
-        return source.divide(value);
+        return source.divide(value, MathContext.DECIMAL128);
     }
 }

--- a/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/transform/math/internal/DivideTransformationServiceTest.java
+++ b/bundles/org.smarthomej.transform.math/src/test/java/org/smarthomej/transform/math/internal/DivideTransformationServiceTest.java
@@ -37,6 +37,13 @@ class DivideTransformationServiceTest {
     }
 
     @Test
+    public void testTransform2() throws TransformationException {
+        String result = subject.transform("3", "1");
+
+        assertEquals("0.3333333333333333333333333333333333", result);
+    }
+
+    @Test
     public void testTransformInsideString() throws TransformationException {
         String result = subject.transform("60", "90 watts");
 


### PR DESCRIPTION
The missing MathContext leads to ArithemticException if the result is a non-terminating decimal expansion.

Signed-off-by: Jan N. Klug <github@klug.nrw>