### PR TITLE
[onewire] Fix loading of properties

### DIFF
--- a/bundles/org.smarthomej.binding.onewire/pom.xml
+++ b/bundles/org.smarthomej.binding.onewire/pom.xml
@@ -14,4 +14,13 @@
 
   <name>SmartHome/J Add-ons :: Bundles :: OneWire Binding</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.smarthomej.addons.bundles</groupId>
+      <artifactId>org.smarthomej.commons</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/bundles/org.smarthomej.binding.onewire/src/main/feature/feature.xml
+++ b/bundles/org.smarthomej.binding.onewire/src/main/feature/feature.xml
@@ -2,6 +2,7 @@
 <features name="org.smarthomej.binding.onewire-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 	<feature name="smarthomej-binding-onewire" description="OneWire Binding" version="${project.version}">
 		<feature>openhab-runtime-base</feature>
+		<bundle dependency="true">mvn:org.smarthomej.addons.bundles/org.smarthomej.commons/${project.version}</bundle>
 		<bundle start-level="80">mvn:org.smarthomej.addons.bundles/org.smarthomej.binding.onewire/${project.version}</bundle>
 	</feature>
 </features>

--- a/bundles/org.smarthomej.binding.onewire/src/main/java/org/smarthomej/binding/onewire/internal/OwBindingConstants.java
+++ b/bundles/org.smarthomej.binding.onewire/src/main/java/org/smarthomej/binding/onewire/internal/OwBindingConstants.java
@@ -25,6 +25,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.smarthomej.binding.onewire.internal.device.OwChannelConfig;
 import org.smarthomej.binding.onewire.internal.device.OwSensorType;
+import org.smarthomej.commons.util.ResourceUtil;
 
 /**
  * The {@link OneWireBinding} class defines common constants, which are
@@ -145,7 +146,7 @@ public class OwBindingConstants {
     public static final Map<OwSensorType, Set<OwChannelConfig>> SENSOR_TYPE_CHANNEL_MAP;
 
     static {
-        Map<String, String> properties = Util.readPropertiesFile("sensor.properties");
+        Map<String, String> properties = ResourceUtil.readProperties(OwBindingConstants.class, "sensor.properties");
         THING_TYPE_MAP = properties.entrySet().stream().filter(e -> e.getKey().endsWith(".thingtype"))
                 .collect(Collectors.toConcurrentMap(e -> OwSensorType.valueOf(e.getKey().split("\\.")[0]),
                         e -> new ThingTypeUID(BINDING_ID, e.getValue())));

--- a/bundles/org.smarthomej.binding.onewire/src/main/java/org/smarthomej/binding/onewire/internal/Util.java
+++ b/bundles/org.smarthomej.binding.onewire/src/main/java/org/smarthomej/binding/onewire/internal/Util.java
@@ -13,12 +13,6 @@
  */
 package org.smarthomej.binding.onewire.internal;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.Map;
-import java.util.Properties;
-import java.util.stream.Collectors;
-
 import javax.measure.quantity.Dimensionless;
 import javax.measure.quantity.Temperature;
 
@@ -27,8 +21,6 @@ import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link Util} is a set of helper functions
@@ -37,8 +29,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class Util {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
-
     /**
      * calculate absolute humidity in g/m³ from measured values
      *
@@ -85,22 +75,5 @@ public class Util {
                 / (((17.62 * 243.12) / (243.12 + theta) - Math.log(rH))));
         State dewPoint = new QuantityType<>(dP, SIUnits.CELSIUS);
         return dewPoint;
-    }
-
-    public static Map<String, String> readPropertiesFile(String filename) {
-        URL resource = Thread.currentThread().getContextClassLoader().getResource(filename);
-        if (resource == null) {
-            LOGGER.warn("Could not read resource file {}, binding will probably fail: resource is null", filename);
-            return Map.of();
-        }
-        Properties properties = new Properties();
-        try {
-            properties.load(resource.openStream());
-            return properties.entrySet().stream()
-                    .collect(Collectors.toMap(e -> (String) e.getKey(), e -> (String) e.getValue()));
-        } catch (IOException e) {
-            LOGGER.warn("Could not read resource file {}, binding will probably fail: {}", filename, e.getMessage());
-            return Map.of();
-        }
     }
 }

--- a/bundles/org.smarthomej.binding.onewire/src/test/java/org/smarthomej/binding/onewire/device/DeviceTestParent.java
+++ b/bundles/org.smarthomej.binding.onewire/src/test/java/org/smarthomej/binding/onewire/device/DeviceTestParent.java
@@ -51,7 +51,7 @@ import org.smarthomej.binding.onewire.internal.handler.OwserverBridgeHandler;
  * @author Jan N. Klug - Initial contribution
  */
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.WARN)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @NonNullByDefault
 public abstract class DeviceTestParent<T extends AbstractOwDevice> {
     private @Nullable Class<T> deviceTestClazz;

--- a/bundles/org.smarthomej.binding.onewire/src/test/java/org/smarthomej/binding/onewire/test/AbstractThingHandlerTest.java
+++ b/bundles/org.smarthomej.binding.onewire/src/test/java/org/smarthomej/binding/onewire/test/AbstractThingHandlerTest.java
@@ -57,7 +57,7 @@ import org.smarthomej.binding.onewire.internal.handler.OwserverBridgeHandler;
  * @author Jan N. Klug - Initial contribution
  */
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.WARN)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @NonNullByDefault
 public abstract class AbstractThingHandlerTest extends JavaTest {
 


### PR DESCRIPTION
On newer openHAB versions the loading via the thread context class loader fails. The `ResourceUtil` in the commons package correctly uses the class's own class loader.

Signed-off-by: Jan N. Klug <github@klug.nrw>