### PR TITLE
[deconz] Fix initialization error after thing update

### DIFF
--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/DeconzBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/handler/DeconzBridgeHandler.java
@@ -37,6 +37,7 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.io.net.http.WebSocketFactory;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
@@ -120,6 +121,15 @@ public class DeconzBridgeHandler extends BaseBridgeHandler implements WebSocketC
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
+    }
+
+    @Override
+    public void thingUpdated(Thing thing) {
+        dispose();
+        this.thing = thing;
+        // we need to create a new websocket connection, because it can't be restarted
+        webSocketConnection = createNewWebSocketConnection();
+        initialize();
     }
 
     /**

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/netutils/WebSocketConnection.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/netutils/WebSocketConnection.java
@@ -136,6 +136,7 @@ public class WebSocketConnection {
             logger.debug("{} encountered an error while closing connection", socketName, e);
         }
         client.destroy();
+        connectionState = ConnectionState.DISCONNECTED;
     }
 
     public void registerListener(ResourceType resourceType, String sensorID, WebSocketMessageListener listener) {


### PR DESCRIPTION
The default implementation after a thing update uses the same handler. Because of that the websocket connection destroyed in the call to `dispose` is re-used which results in an error. Also the `DISCONNECTED` state was not properly set when disposing the thing.

Signed-off-by: Jan N. Klug <github@klug.nrw>