### PR TITLE
[deconz] Properly handle unused group types

### DIFF
--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/discovery/ThingDiscoveryService.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/discovery/ThingDiscoveryService.java
@@ -137,6 +137,11 @@ public class ThingDiscoveryService extends AbstractDiscoveryService implements D
             case LIGHT_GROUP:
                 thingTypeUID = THING_TYPE_LIGHTGROUP;
                 break;
+            case LUMINAIRE:
+            case LIGHT_SOURCE:
+            case ROOM:
+                logger.debug("Group {} ({}), type {} ignored.", group.id, group.name, group.type);
+                return;
             default:
                 logger.debug(
                         "Found group: {} ({}), type {} but no thing type defined for that type. This should be reported.",

--- a/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/types/GroupType.java
+++ b/bundles/org.smarthomej.binding.deconz/src/main/java/org/smarthomej/binding/deconz/internal/types/GroupType.java
@@ -30,6 +30,9 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public enum GroupType {
     LIGHT_GROUP("LightGroup"),
+    LUMINAIRE("Luminaire"),
+    ROOM("Room"),
+    LIGHT_SOURCE("Lightsource"),
     UNKNOWN("");
 
     private static final Map<String, GroupType> MAPPING = Arrays.stream(GroupType.values())


### PR DESCRIPTION
The Phoscon App creates "Luminaire" groups for some devices with RGBW capability (combining color and dimmable light). Since they are also created as single devices and we control ct and color with two channels anyway, these groups can be ignored. 

Signed-off-by: Jan N. Klug <github@klug.nrw>