### PR TITLE
[androiddebugbridge] Handle java.net.ConnectException

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDevice.java
@@ -58,6 +58,9 @@ import com.tananaev.adblib.AdbStream;
 @NonNullByDefault
 public class AndroidDebugBridgeDevice {
     public static final int ANDROID_MEDIA_STREAM = 3;
+    private static final String EXCEPTION_STREAM_OPEN_ACTIVELY_REJECTED_BY_REMOTE_PEER = "Stream open actively rejected by remote peer";
+    private static final String EXCEPTION_CONNECT_MUST_BE_CALLED_FIRST = "connect() must be called first";
+    private static final String EXCEPTION_STREAM_CLOSED = "Stream closed";
     private static final String ADB_FOLDER = OpenHAB.getUserDataFolder() + File.separator + ".adb";
     private static final Logger LOGGER = LoggerFactory.getLogger(AndroidDebugBridgeDevice.class);
     private static final Pattern VOLUME_PATTERN = Pattern
@@ -454,7 +457,9 @@ public class AndroidDebugBridgeDevice {
                     } while (!stream.isClosed());
                 } catch (IOException | IllegalStateException e) {
                     String message = e.getMessage();
-                    if (!"Stream closed".equals(message) && !"connect() must be called first".equals(message)) {
+                    if (!EXCEPTION_STREAM_CLOSED.equals(message) && //
+                    !EXCEPTION_CONNECT_MUST_BE_CALLED_FIRST.equals(message) && //
+                    !EXCEPTION_STREAM_OPEN_ACTIVELY_REJECTED_BY_REMOTE_PEER.equals(message)) {
                         throw e;
                     }
                 }


### PR DESCRIPTION
- Handle java.net.ConnectException

```
2022-07-21 21:46:10.383 [WARN ] [mmon.WrappedScheduledExecutorService] - Scheduled runnable ended with an exception: 
java.net.ConnectException: Stream open actively rejected by remote peer
        at com.tananaev.adblib.AdbConnection.open(AdbConnection.java:342) ~[?:?]
        at org.smarthomej.binding.androiddebugbridge.internal.AndroidDebugBridgeDevice.lambda$0(AndroidDebugBridgeDevice.java:451) ~[?:?]
        at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
        at java.lang.Thread.run(Unknown Source) [?:?]
```

This does not look like the best solution but other exceptions are handled in a similar way. imo the `java.net.ConnectException` can be catched seperately and handled that way.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>