### PR TITLE
[tuya] add status DP to remote schema parsing

### DIFF
--- a/bundles/org.smarthomej.binding.tuya/src/main/resources/schema.json
+++ b/bundles/org.smarthomej.binding.tuya/src/main/resources/schema.json
@@ -21575,7 +21575,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -23364,7 +23364,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -24148,7 +24148,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -24676,7 +24676,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -49598,7 +49598,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -60662,7 +60662,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMdoe": {
+		"SilentMode": {
 			"id": 117,
 			"type": "bool"
 		},

--- a/bundles/org.smarthomej.binding.tuya/src/main/resources/schema.json
+++ b/bundles/org.smarthomej.binding.tuya/src/main/resources/schema.json
@@ -21575,7 +21575,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMode": {
+		"SilentMdoe": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -23364,7 +23364,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMode": {
+		"SilentMdoe": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -24148,7 +24148,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMode": {
+		"SilentMdoe": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -24676,7 +24676,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMode": {
+		"SilentMdoe": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -49598,7 +49598,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMode": {
+		"SilentMdoe": {
 			"id": 117,
 			"type": "bool"
 		},
@@ -60662,7 +60662,7 @@
 			"id": 116,
 			"type": "bitmap"
 		},
-		"SilentMode": {
+		"SilentMdoe": {
 			"id": 117,
 			"type": "bool"
 		},


### PR DESCRIPTION
The schema reported from the cloud consists of functions and status. This adds the formerly ignored status DPs (if they are not already present because they are also functions).

Signed-off-by: Jan N. Klug <github@klug.nrw>