### PR TITLE
[androiddebugbridge] Remove package prefix while determination of current running package

### DIFF
--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/main/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeHandler.java
@@ -257,7 +257,7 @@ public class AndroidDebugBridgeHandler extends UpdatingBaseThingHandler {
         if (command instanceof RefreshType) {
             boolean playing;
             String lastCurrentPackage = (String) channelLastStateMap.getOrDefault(CURRENT_PACKAGE_CHANNEL, "");
-            String currentPackage = lastCurrentPackage.isEmpty() ? adbConnection.getCurrentPackage()
+            String currentPackage = lastCurrentPackage.isBlank() ? adbConnection.getCurrentPackage()
                     : lastCurrentPackage;
             AndroidDebugBridgeMediaStatePackageConfig currentPackageConfig = packageConfigs != null ? Arrays
                     .stream(packageConfigs).filter(pc -> pc.name.equals(currentPackage)).findFirst().orElse(null)

--- a/bundles/org.smarthomej.binding.androiddebugbridge/src/test/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDeviceTest.java
+++ b/bundles/org.smarthomej.binding.androiddebugbridge/src/test/java/org/smarthomej/binding/androiddebugbridge/internal/AndroidDebugBridgeDeviceTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2021-2022 Contributors to the SmartHome/J project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.smarthomej.binding.androiddebugbridge.internal;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.regex.Matcher;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+class AndroidDebugBridgeDeviceTest {
+
+    @Test
+    void testCurrentPackagePrefixFilter() {
+        Matcher currentPackageMatcher = AndroidDebugBridgeDevice.CURRENT_PACKAGE_PREFIX_FILTER_PATTERN
+                .matcher("12345:org.android.avod");
+        assertTrue(currentPackageMatcher.find());
+        assertEquals("org.android.avod", currentPackageMatcher.group(2));
+
+        currentPackageMatcher = AndroidDebugBridgeDevice.CURRENT_PACKAGE_PREFIX_FILTER_PATTERN
+                .matcher("org.android.avod");
+        assertTrue(currentPackageMatcher.find());
+        assertEquals("org.android.avod", currentPackageMatcher.group(2));
+    }
+}


### PR DESCRIPTION
- Remove package prefix while determination of current running package

On some android versions the current package start with an numeric prefix like "12345:org.android.avod". In general we are only interested in the package name. This PR added a fix to strip the prefix.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>