### PR TITLE
[viessmann] fix NullPointerException featuresData list

### DIFF
--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
@@ -263,8 +263,12 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
             countApiCalls();
             if (allFeatures != null) {
                 List<FeatureDataDTO> featuresData = allFeatures.data;
-                for (FeatureDataDTO featureDataDTO : featuresData) {
-                    notifyChildHandlers(featureDataDTO);
+                if (featuresData != null) {
+                    for (FeatureDataDTO featureDataDTO : featuresData) {
+                        notifyChildHandlers(featureDataDTO);
+                    }
+                } else {
+                    logger.warn("Features list is empty.");
                 }
             }
         } catch (JsonSyntaxException | IllegalStateException e) {


### PR DESCRIPTION
This PR fixes the NullPointerException in the featuresData list. Reported in the openHAB community [https://community.openhab.org/t/binding-smarthome-j-viessmann-binding-looses-connection/140765](url)

Signed-off-by: Ronny Grun <ronny.grun@t-online.de>