### PR TITLE
[viessmann] add status channel for OneTimeCharge

### DIFF
--- a/bundles/org.smarthomej.binding.viessmann/README.md
+++ b/bundles/org.smarthomej.binding.viessmann/README.md
@@ -2,7 +2,7 @@
 
 <img src="org.smarthomej.binding.viessmann/doc/viessmann_wordmark_rgb_1_vitorange.png" width="140"/>
 
-This binding connects Viessmann Heatings via the new Viessmann API.
+This binding connects Viessmann Heating via the new Viessmann API.
 It provides features like the ViCare-App.
 
 ## Note / Important
@@ -17,13 +17,13 @@ You have to register your ViCare Account at the [Viessmann developer portal](htt
 
 ### Hint: 
 
-On the Viessman developer portal you can add more than one RedirectURI by tapping the plus sign.
+On the Viessmann developer portal you can add more than one RedirectURI by tapping the plus sign.
 
 ## Supported Things
 
 The binding supports the following thing types:
 
-* `bridge` - Supports connection to the Viesmmann API.
+* `bridge` - Supports connection to the Viessmann API.
 * `device` - Provides a device which is connected (Discovery)
 
 ## Discovery
@@ -34,18 +34,19 @@ Discovery is supported for all devices connected in your account.
 
 The `bridge` thing supports the connection to the Viessmann API.
 
-* `apiKey` (required) The Client ID from the Viessman developer portal 
+* `apiKey` (required) The Client ID from the Viessmann developer portal 
 * `user` (required) The E-Mail address which is registered for the ViCare App
 * `password` (required) The password which is registered for the ViCare App
-* `installationId` (optional / it will be discovered) The installation Id which belongs to your installation 
+* `installationId` (optional / it will be discovered) The installation ID which belongs to your installation 
 * `gatewaySerial` (optional / it will be discovered) The gateway serial which belongs to your installation
 * `apiCallLimit` (default = 1450) The limit how often call the API (*) 
 * `bufferApiCommands` (default = 450) The buffer for commands (*)
 * `pollingInterval` (default = 0) How often the available devices should be queried in seconds (**) 
 * `pollingIntervalErrors` (default = 60) How often the errors should be queried in minutes 
+* `disablePolling` (default = OFF) Deactivates the polling to carry out the manual poll using an item
 
 
-(*) Used to calcuate refresh time in seconds.
+(*) Used to calculate refresh time in seconds.
 (**) If set to 0, then the interval will be calculated by the binding.
 
 ## Thing Configuration
@@ -56,11 +57,13 @@ _All configurations are made in the UI_
 
 ### `bridge`
 
-| channel            | type   | RO/RW | description                                 |
-|--------------------|--------|-------|---------------------------------------------|
-| `countApiCalls`    | Number |   RO  | How often the API is called this day        |
-| `errorIsActive`    | Switch |   RO  | Indicates whether the error is set / unset  |
-| `lastErrorMessage` | String |   RO  | Last error message from the installation    |
+| channel             | type   | RO/RW | description                                |
+|---------------------|--------|-------|--------------------------------------------|
+| `countApiCalls`     | Number | RO    | How often the API is called this day       |
+| `errorIsActive`     | Switch | RO    | Indicates whether the error is set / unset |
+| `lastErrorMessage`  | String | RO    | Last error message from the installation   |
+| `runQueryOnce`      | Switch | W     | Run device query once                      |
+| `runErrorQueryOnce` | Switch | W     | Run error query once                       |
 
 
 ### `device`
@@ -80,5 +83,5 @@ The item type of each item has to be adjusted:
 | unit              | old item type | new item type         |
 |-------------------|---------------|-----------------------|
 | hour, minutes,... | Number        | Number:Time           |
-| percent           | Nubmer        | Number:Dimensionless  |
+| percent           | Number        | Number:Dimensionless  |
 | temperature       | Number        | Number:Temperature    |

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/ViessmannBindingConstants.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/ViessmannBindingConstants.java
@@ -72,4 +72,7 @@ public class ViessmannBindingConstants {
 
     public static final Map<String, String> MODES_MAP = ResourceUtil.readProperties(ViessmannBindingConstants.class,
             "modes.properties");
+
+    public static final String CHANNEL_RUN_QUERY_ONCE = "runQueryOnce";
+    public static final String CHANNEL_RUN_ERROR_QUERY_ONCE = "runErrorQueryOnce";
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/config/BridgeConfiguration.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/config/BridgeConfiguration.java
@@ -31,5 +31,5 @@ public class BridgeConfiguration {
     public int bufferApiCommands = 450;
     public int pollingInterval = 0;
     public int pollingIntervalErrors = 60;
-    public Boolean disablePolling = false;
+    public boolean disablePolling = false;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/config/BridgeConfiguration.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/config/BridgeConfiguration.java
@@ -31,4 +31,5 @@ public class BridgeConfiguration {
     public int bufferApiCommands = 450;
     public int pollingInterval = 0;
     public int pollingIntervalErrors = 60;
+    public Boolean disablePolling = false;
 }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
@@ -759,7 +759,7 @@ public class DeviceHandler extends ViessmannThingHandler {
                         case "changeEndDate":
                             prop.put("changeEndDateUri", commands.changeEndDate.uri);
                             prop.put("command", "changeEndDate,schedule,unschedule");
-                            prop.put("changeEndDatParams", "end");
+                            prop.put("changeEndDateParams", "end");
                             prop.put("scheduleParams", "start,end");
                             prop.put("unscheduleParams", "{}");
                             break;

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
@@ -225,6 +225,8 @@ public class DeviceHandler extends ViessmannThingHandler {
                             }
                         }
                     }
+                } else {
+                    initChannelState();
                 }
             }
         } catch (IllegalArgumentException e) {

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
@@ -21,8 +21,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -218,8 +216,7 @@ public class DeviceHandler extends ViessmannThingHandler {
                                 : (ViessmannBridgeHandler) bridge.getHandler();
                         if (bridgeHandler != null) {
                             if (!bridgeHandler.setData(uri, param) || initState) {
-                                ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-                                executorService.schedule(this::initChannelState, initStateDelay, TimeUnit.SECONDS);
+                                scheduler.schedule(this::initChannelState, initStateDelay, TimeUnit.SECONDS);
                             }
                         }
                     }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
@@ -186,9 +186,7 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
         getAllDevices();
         if (!devicesList.isEmpty()) {
             updateBridgeStatus(ThingStatus.ONLINE);
-            if (!config.disablePolling) {
-                startViessmannBridgePolling(getPollingInterval(), 1);
-            }
+            startViessmannBridgePolling(getPollingInterval(), 1);
         }
     }
 
@@ -295,11 +293,13 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
         ScheduledFuture<?> currentPollingJob = viessmannBridgePollingJob;
         if (currentPollingJob == null) {
             viessmannBridgePollingJob = scheduler.scheduleWithFixedDelay(() -> {
-                logger.debug("Refresh job scheduled to run every {} seconds for '{}'", pollingIntervalS,
-                        getThing().getUID());
                 api.checkExpiringToken();
                 checkResetApiCalls();
-                pollingFeatures();
+                if (!config.disablePolling) {
+                    logger.debug("Refresh job scheduled to run every {} seconds for '{}'", pollingIntervalS,
+                            getThing().getUID());
+                    pollingFeatures();
+                }
             }, initialDelay, pollingIntervalS, TimeUnit.SECONDS);
         }
     }

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
@@ -132,23 +132,15 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (channelUID.getId().equals(CHANNEL_RUN_QUERY_ONCE)) {
-            if (command instanceof OnOffType) {
-                if (command == OnOffType.ON) {
-                    logger.debug("Received command: CHANNEL_RUN_QUERY_ONCE");
-                    pollingFeatures();
-                    updateState(CHANNEL_RUN_QUERY_ONCE, OnOffType.OFF);
-                }
-            }
+        if (channelUID.getId().equals(CHANNEL_RUN_QUERY_ONCE) && OnOffType.ON.equals(command)) {
+            logger.debug("Received command: CHANNEL_RUN_QUERY_ONCE");
+            pollingFeatures();
+            updateState(CHANNEL_RUN_QUERY_ONCE, OnOffType.OFF);
         }
-        if (channelUID.getId().equals(CHANNEL_RUN_ERROR_QUERY_ONCE)) {
-            if (command instanceof OnOffType) {
-                if (command == OnOffType.ON) {
-                    logger.debug("Received command: CHANNEL_RUN_ERROR_QUERY_ONCE");
-                    getDeviceError();
-                    updateState(CHANNEL_RUN_ERROR_QUERY_ONCE, OnOffType.OFF);
-                }
-            }
+        if (channelUID.getId().equals(CHANNEL_RUN_ERROR_QUERY_ONCE) && OnOffType.ON.equals(command)) {
+            logger.debug("Received command: CHANNEL_RUN_ERROR_QUERY_ONCE");
+            getDeviceError();
+            updateState(CHANNEL_RUN_ERROR_QUERY_ONCE, OnOffType.OFF);
         }
     }
 
@@ -179,7 +171,7 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
             setConfigInstallationGatewayId();
         }
 
-        if (errorChannelsLinked() && !config.disablePolling) {
+        if (!config.disablePolling && errorChannelsLinked()) {
             startViessmannErrorsPolling(config.pollingIntervalErrors);
         }
 

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
@@ -132,7 +132,24 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        // Nothing to handle here currently
+        if (channelUID.getId().equals(CHANNEL_RUN_QUERY_ONCE)) {
+            if (command instanceof OnOffType) {
+                if (command == OnOffType.ON) {
+                    logger.debug("Received command: CHANNEL_RUN_QUERY_ONCE");
+                    pollingFeatures();
+                    updateState(CHANNEL_RUN_QUERY_ONCE, OnOffType.OFF);
+                }
+            }
+        }
+        if (channelUID.getId().equals(CHANNEL_RUN_ERROR_QUERY_ONCE)) {
+            if (command instanceof OnOffType) {
+                if (command == OnOffType.ON) {
+                    logger.debug("Received command: CHANNEL_RUN_ERROR_QUERY_ONCE");
+                    getDeviceError();
+                    updateState(CHANNEL_RUN_ERROR_QUERY_ONCE, OnOffType.OFF);
+                }
+            }
+        }
     }
 
     @Override
@@ -162,14 +179,16 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
             setConfigInstallationGatewayId();
         }
 
-        if (errorChannelsLinked()) {
+        if (errorChannelsLinked() && !config.disablePolling) {
             startViessmannErrorsPolling(config.pollingIntervalErrors);
         }
 
         getAllDevices();
         if (!devicesList.isEmpty()) {
             updateBridgeStatus(ThingStatus.ONLINE);
-            startViessmannBridgePolling(getPollingInterval(), 1);
+            if (!config.disablePolling) {
+                startViessmannBridgePolling(getPollingInterval(), 1);
+            }
         }
     }
 

--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/ViessmannBridgeHandler.java
@@ -253,9 +253,9 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
 
     private void checkResetApiCalls() {
         LocalTime time = LocalTime.now();
-        if (time.isAfter(LocalTime.of(00, 00, 01)) && (time.isBefore(LocalTime.of(01, 00, 00)))) {
+        if (time.isAfter(LocalTime.of(0, 0, 1)) && (time.isBefore(LocalTime.of(1, 0, 0)))) {
             if (countReset) {
-                logger.debug("Resettig API call counts");
+                logger.debug("Resetting API call counts");
                 apiCalls = 0;
                 countReset = false;
             }
@@ -268,7 +268,7 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
         List<String> devices = pollingDevicesList;
         if (devices != null) {
             for (String deviceId : devices) {
-                logger.debug("Loading featueres from Device ID: {}", deviceId);
+                logger.debug("Loading features from Device ID: {}", deviceId);
                 getAllFeaturesByDeviceId(deviceId);
             }
         }
@@ -379,7 +379,7 @@ public class ViessmannBridgeHandler extends UpdatingBaseBridgeHandler {
     }
 
     /**
-     * Notify appropriate child thing handlers of an Viessmann message by calling their handleUpdate() methods.
+     * Notify appropriate child thing handlers of a Viessmann message by calling their handleUpdate() methods.
      *
      * @param msg message to forward to child handler(s)
      */

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -17,6 +17,12 @@
 			<channel id="lastErrorMessage" typeId="lastErrorMessage">
 				<label>Last error message</label>
 			</channel>
+			<channel id="runQueryOnce" typeId="runQueryOnce">
+				<label>Run device query once</label>
+			</channel>
+			<channel id="runErrorQueryOnce" typeId="runErrorQueryOnce">
+				<label>Run error query once</label>
+			</channel>
 		</channels>
 		<properties>
 			<property name="thingTypeVersion">3</property>
@@ -45,6 +51,12 @@
 			<parameter name="gatewaySerial" type="text" required="false">
 				<label>GatewaySerial ID</label>
 				<description>The gatewaySerial</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="disablePolling" type="boolean" required="false">
+				<label>Disable polling</label>
+				<description>Deactivates the polling to carry out the manual poll using an item</description>
+				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="apiCallLimit" type="integer" required="false">
@@ -217,6 +229,18 @@
 		<item-type>Switch</item-type>
 		<label>Switch</label>
 		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="runQueryOnce" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Run device query once</label>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="runErrorQueryOnce" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Run error query once</label>
+		<category>Error</category>
 	</channel-type>
 
 	<channel-type id="errorIsActive">

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -231,6 +231,13 @@
 		<category>Switch</category>
 	</channel-type>
 
+	<channel-type id="type-boolean-readOnly">
+		<item-type>Switch</item-type>
+		<label>Switch</label>
+		<category>Switch</category>
+		<state readOnly="true"/>
+	</channel-type>
+
 	<channel-type id="runQueryOnce" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Run device query once</label>

--- a/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/resources/OH-INF/thing/thing-types.xml
@@ -61,14 +61,14 @@
 			</parameter>
 			<parameter name="apiCallLimit" type="integer" required="false">
 				<label>API call limit</label>
-				<description>The limit how often call the API. For calcutating the time how often the data is queried in
+				<description>The limit how often call the API. For calculating the time how often the data is queried in
 					seconds</description>
 				<default>1450</default>
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="bufferApiCommands" type="integer" required="false">
 				<label>Buffer for API commands</label>
-				<description>The buffer for commands. For calcutating the time how often the data is queried in seconds</description>
+				<description>The buffer for commands. For calculating the time how often the data is queried in seconds</description>
 				<default>450</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -81,7 +81,7 @@
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="pollingIntervalErrors" type="integer" required="false" unit="min">
-				<label>Polling Interval Erros</label>
+				<label>Polling Interval Errors</label>
 				<description>How often the errors should be queried in minutes</description>
 				<default>60</default>
 				<advanced>true</advanced>


### PR DESCRIPTION
This PR: 
Adds a channel which provides the state of OneTimeCharge. (Device Thing)
Adds the ability to disable polling. (Bridge Thing)
Adds channels for manual polling. (Bridge Thing)

Improves the channel type for channels w/o commands to read-only.

Also fixes some typo.

Signed-off-by: Ronny Grun <ronny.grun@t-online.de>
