### PR TITLE
[viessmann] fix channel link poll

### DIFF
--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/handler/DeviceHandler.java
@@ -220,8 +220,6 @@ public class DeviceHandler extends ViessmannThingHandler {
                             }
                         }
                     }
-                } else {
-                    initChannelState();
                 }
             }
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Fixes the issue, when channels are newly linked, a poll is made for each link. 
This is not wanted because it increases the API queries.

Signed-off-by: Ronny Grun <ronny.grun@t-online.de>