### PR TITLE
[knx] Fix things do not initialize after initial bridge creation

### DIFF
--- a/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/IPBridgeThingHandler.java
+++ b/bundles/org.smarthomej.binding.knx/src/main/java/org/smarthomej/binding/knx/internal/handler/IPBridgeThingHandler.java
@@ -103,9 +103,9 @@ public class IPBridgeThingHandler extends KNXBridgeBaseThingHandler {
         IPClient client = new IPClient(ipConnectionType, ip, localSource, port, localEndPoint, useNAT,
                 autoReconnectPeriod, thing.getUID(), config.getResponseTimeout(), config.getReadingPause(),
                 config.getReadRetriesLimit(), getScheduler(), this);
-        client.initialize();
-
         this.client = client;
+
+        client.initialize();
     }
 
     @Override


### PR DESCRIPTION
In some cases child things stayed OFFLINE when the bridged changed to ONLINE because the `getClient` method returned a `NoOpClient`. The reason is that the `client` field in the bridge handler was set after the client has been initialized.

Signed-off-by: Jan N. Klug <github@klug.nrw>