### PR TITLE
[basicprofiles] Remove redundant call to onStateUpdateFromItem to avoid endless loops

### DIFF
--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/profiles/InvertStateProfile.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/profiles/InvertStateProfile.java
@@ -59,7 +59,7 @@ public class InvertStateProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.sendUpdate((State) invert(state));
+        // do nothing
     }
 
     @Override

--- a/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/profiles/RoundStateProfile.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/main/java/org/smarthomej/transform/basicprofiles/internal/profiles/RoundStateProfile.java
@@ -85,7 +85,7 @@ public class RoundStateProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.sendUpdate((State) applyRound(state));
+        // do nothing
     }
 
     @Override

--- a/bundles/org.smarthomej.transform.basicprofiles/src/test/java/org/smarthomej/transform/basicprofiles/internal/profiles/InvertStateProfileTest.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/test/java/org/smarthomej/transform/basicprofiles/internal/profiles/InvertStateProfileTest.java
@@ -93,7 +93,6 @@ public class InvertStateProfileTest {
     public void testOnStateUpdateFromHandler(ParameterSet parameterSet) {
         final StateProfile profile = initProfile();
         if (parameterSet.type instanceof State && parameterSet.resultingType instanceof State) {
-            verifyStateUpdateFromItem(profile, (State) parameterSet.type, (State) parameterSet.resultingType);
             verifyStateUpdateFromHandler(profile, (State) parameterSet.type, (State) parameterSet.resultingType);
         }
     }
@@ -112,12 +111,6 @@ public class InvertStateProfileTest {
         reset(mockCallback);
         profile.onCommandFromHandler(command);
         verify(mockCallback, times(1)).sendCommand(eq(result));
-    }
-
-    private void verifyStateUpdateFromItem(StateProfile profile, State state, State result) {
-        reset(mockCallback);
-        profile.onStateUpdateFromItem(state);
-        verify(mockCallback, times(1)).sendUpdate(eq(result));
     }
 
     private void verifyStateUpdateFromHandler(StateProfile profile, State state, State result) {

--- a/bundles/org.smarthomej.transform.basicprofiles/src/test/java/org/smarthomej/transform/basicprofiles/internal/profiles/RoundStateProfileTest.java
+++ b/bundles/org.smarthomej.transform.basicprofiles/src/test/java/org/smarthomej/transform/basicprofiles/internal/profiles/RoundStateProfileTest.java
@@ -34,7 +34,6 @@ import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
 import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 
 /**
  * Basic unit tests for {@link RoundStateProfile}.
@@ -125,22 +124,6 @@ public class RoundStateProfileTest {
     }
 
     @Test
-    public void testDecimalTypeOnStateUpdateFromItem() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        RoundStateProfile roundProfile = createProfile(callback, 2);
-
-        State state = new DecimalType(23.666);
-        roundProfile.onStateUpdateFromItem(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).sendUpdate(capture.capture());
-
-        State result = capture.getValue();
-        DecimalType dtResult = (DecimalType) result;
-        assertThat(dtResult.doubleValue(), is(23.67));
-    }
-
-    @Test
     public void testQuantityTypeOnCommandFromItem() {
         ProfileCallback callback = mock(ProfileCallback.class);
         RoundStateProfile roundProfile = createProfile(callback, 1);
@@ -155,24 +138,6 @@ public class RoundStateProfileTest {
         @SuppressWarnings("unchecked")
         QuantityType<Temperature> qtResult = (QuantityType<Temperature>) result;
         assertThat(qtResult.doubleValue(), is(23.3));
-        assertThat(qtResult.getUnit(), is(SIUnits.CELSIUS));
-    }
-
-    @Test
-    public void testQuantityTypeOnStateUpdateFromItem() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        RoundStateProfile roundProfile = createProfile(callback, 1);
-
-        State state = new QuantityType<Temperature>("23.666 °C");
-        roundProfile.onStateUpdateFromItem(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).sendUpdate(capture.capture());
-
-        State result = capture.getValue();
-        @SuppressWarnings("unchecked")
-        QuantityType<Temperature> qtResult = (QuantityType<Temperature>) result;
-        assertThat(qtResult.doubleValue(), is(23.7));
         assertThat(qtResult.getUnit(), is(SIUnits.CELSIUS));
     }
 


### PR DESCRIPTION
- Remove redundant call to onStateUpdateFromItem to avoid endless loops

See https://github.com/smarthomej/addons/pull/95#discussion_r1168337321

Closes https://github.com/smarthomej/addons/issues/477

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>