### PR TITLE
[http] Better handle invalid 401 response

### DIFF
--- a/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/HttpResponseListener.java
+++ b/bundles/org.smarthomej.binding.http/src/main/java/org/smarthomej/binding/http/internal/http/HttpResponseListener.java
@@ -63,7 +63,7 @@ public class HttpResponseListener extends BufferingResponseListener {
             logger.trace("Received from '{}': {}", result.getRequest().getURI(), responseToLogString(response));
         }
         Request request = result.getRequest();
-        if (result.isFailed()) {
+        if (response == null || (result.isFailed() && response.getStatus() != 401)) {
             logger.debug("Requesting '{}' (method='{}', content='{}') failed: {}", request.getURI(),
                     request.getMethod(), request.getContent(), result.getFailure().getMessage());
             future.complete(null);


### PR DESCRIPTION
It has been discovered that some servers respond with a 401 without `WWW-Authenticate` header if the original request was sent with creentials. While this is a protocol violation, the user can't fix it, because it is server-side. This PR handles these edge cases more gracefully.