### PR TITLE
[viessmann] fix IllegalStateException while parsing JSON

### DIFF
--- a/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/api/ViessmannApi.java
+++ b/bundles/org.smarthomej.binding.viessmann/src/main/java/org/smarthomej/binding/viessmann/internal/api/ViessmannApi.java
@@ -215,6 +215,7 @@ public class ViessmannApi {
         String response = executeGet(VIESSMANN_BASE_URL + "iot/v1/features/installations/" + installationId
                 + "/gateways/" + gatewaySerial + "/devices/" + deviceId + "/features/");
         if (response != null) {
+            response = response.replaceAll("\\n", "").replaceAll("\\r", "").replaceAll(" ", "");
             response = response.replace("enum", "enumValue");
             int i = response.indexOf("\"entries\":{\"type\":\"array\",\"value\"");
             while (i > 0) {


### PR DESCRIPTION
Viessmann changed the JSON response and added spaces and CR/LF. This PR removes these so that some needed values ​​can be searched and replaced.

This error was reported via email.