### PR TITLE
Correct sendAsString typo

### DIFF
--- a/bundles/org.smarthomej.binding.tuya/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.smarthomej.binding.tuya/src/main/resources/OH-INF/thing/thing-types.xml
@@ -175,7 +175,7 @@
 			<parameter name="max" type="integer">
 				<label>Maximum</label>
 			</parameter>
-			<parameter name="sendAdString" type="boolean">
+			<parameter name="sendAsString" type="boolean">
 				<label>Send As String</label>
 				<description>Send the value as string instead of number.</description>
 				<default>false</default>


### PR DESCRIPTION
The parameter name in the resource file is "sendAdString" instead of "sendAsString".

However... given that it's been wrong for a year, defaults to off, couldn't be changed, and no one has complained maybe the "sendAsString" support should just be removed?