### PR TITLE
Poll with DP_QUERY instead of DP_REFRESH

### DIFF
--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -223,8 +224,10 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
             int pollingInterval = configuration.pollingInterval;
             TuyaDevice tuyaDevice = this.tuyaDevice;
             if (tuyaDevice != null && pollingInterval > 0) {
-                pollingJob = scheduler.scheduleWithFixedDelay(tuyaDevice::requestStatus, pollingInterval,
-                        pollingInterval, TimeUnit.SECONDS);
+                pollingJob = scheduler.scheduleWithFixedDelay(() -> {
+                    tuyaDevice.refreshStatus(
+                            Stream.concat(dpToChannelId.keySet().stream(), dp2ToChannelId.keySet().stream()).toList());
+                }, pollingInterval, pollingInterval, TimeUnit.SECONDS);
             }
 
             // start learning code if thing is online and presents 'ir-code' channel

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -223,7 +223,7 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
             int pollingInterval = configuration.pollingInterval;
             TuyaDevice tuyaDevice = this.tuyaDevice;
             if (tuyaDevice != null && pollingInterval > 0) {
-                pollingJob = scheduler.scheduleWithFixedDelay(tuyaDevice::refreshStatus, pollingInterval,
+                pollingJob = scheduler.scheduleWithFixedDelay(tuyaDevice::requestStatus, pollingInterval,
                         pollingInterval, TimeUnit.SECONDS);
             }
 

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/TuyaDevice.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/local/TuyaDevice.java
@@ -132,11 +132,12 @@ public class TuyaDevice implements ChannelFutureListener {
         }
     }
 
-    public void refreshStatus() {
-        MessageWrapper<?> m = new MessageWrapper<>(DP_REFRESH, Map.of("dpId", List.of(4, 5, 6, 18, 19, 20)));
+    public void refreshStatus(List<Integer> dps) {
+        MessageWrapper<?> m = new MessageWrapper<>(DP_REFRESH, Map.of("dpId", dps));
         Channel channel = this.channel;
         if (channel != null) {
             channel.writeAndFlush(m);
+            requestStatus();
         } else {
             logger.warn("{}: Refreshing status failed. Device is not connected.", deviceId);
         }


### PR DESCRIPTION
Should polling use DP_QUERY to request current DP values rather than DP_REFRESH?

The only Tuya devices I have available are some (identical) smart plugs using the 3.5 protocol (for which I'm using the @CyborgAndy patches [here](https://github.com/CyborgAndy/smarthomej-addons.git)). However...

Using refreshStatus, which sends a DP_REFRESH, I get a response payload of "query dp failed". Doing a requestStatus, which sends a DP_QUERY, gets the full set of DPs as expected.

I have a suspicion that a DP_REFRESH is intended to trigger underlying sampling and return the new DP values and that "query dp failed" means no requested DPs were triggerable. DP_QUERY, on the other hand, is just a request for current values of DPs.

On the gripping hand these my plugs seem to do continuous sampling and the values returned for a DP_QUERY do update.Other devices, battery devices in particular, may only sample on request and need to be polled with DP_REFRESH? I have no way of testing this :-(

N.B. Issue #609 seems to imply that some smart plugs can be DP_REFRESHed for some DPs but the DP_REFRESH will fail if non-existent DPs are requested. My smart plugs fail DP_REFRESH for ANY set of DPs.

So...
 * We definitely need to do a DP_QUERY for some devices
 * We may need to do a DP_REFRESH for some devices
 * If we do a DP_REFRESH we should only request DPs known to exist (or some subset?)

As I said, I have nothing to test further with.

For the record the smart plugs I have are Eightree dual band (2.4GHz/5GHz) UK version (yes, they are advertised as 5GHZ but they are actually dual band)