### PR TITLE
Fix to allow for Channels whose DPs have string values

### DIFF
--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/util/SchemaDp.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/util/SchemaDp.java
@@ -33,6 +33,7 @@ public class SchemaDp {
             "Boolean", "bool", //
             "Enum", "enum", //
             "Integer", "value", //
+            "String", "string", //
             "Json", "string");
 
     public int id = 0;


### PR DESCRIPTION
As title. DPs with string values didn't get Channels created for them because SchemaDp didn't know what to do with them.