### PR TITLE
Get channel labels from schema label or map from schema code

### DIFF
--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/cloud/dto/DeviceSchema.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/cloud/dto/DeviceSchema.java
@@ -36,6 +36,7 @@ public class DeviceSchema {
     public static class Description {
         public String code = "";
         public int dp_id = 0;
+        public String label = "";
         public String type = "";
         public String values = "";
 

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/handler/TuyaDeviceHandler.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/handler/TuyaDeviceHandler.java
@@ -57,6 +57,7 @@ import org.openhab.core.types.Command;
 import org.openhab.core.types.CommandOption;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
+import org.openhab.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smarthomej.binding.tuya.internal.config.ChannelConfiguration;
@@ -499,8 +500,20 @@ public class TuyaDeviceHandler extends BaseThingHandler implements DeviceInfoSub
                 return Map.entry("", ChannelBuilder.create(channelUID).build());
             }
 
-            return Map.entry(channelId, callback.createChannelBuilder(channelUID, channeltypeUID).withLabel(channelId)
-                    .withConfiguration(new Configuration(configuration)).build());
+            if (schemaDp.label.isEmpty()) {
+                schemaDp.label = schemaDp.code;
+
+                String label = StringUtils.capitalizeByWhitespace(schemaDp.code.replaceAll("_", " "));
+                if (label != null) {
+                    label = label.trim();
+                    if (!label.isEmpty()) {
+                        schemaDp.label = label;
+                    }
+                }
+            }
+
+            return Map.entry(channelId, callback.createChannelBuilder(channelUID, channeltypeUID)
+                    .withLabel(schemaDp.label).withConfiguration(new Configuration(configuration)).build());
         }).filter(c -> !c.getKey().isEmpty()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 
         List<String> channelSuffixes = List.of("", "_1", "_2");

--- a/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/util/SchemaDp.java
+++ b/bundles/org.smarthomej.binding.tuya/src/main/java/org/smarthomej/binding/tuya/internal/util/SchemaDp.java
@@ -38,6 +38,7 @@ public class SchemaDp {
     public int id = 0;
     public String code = "";
     public String type = "";
+    public String label = "";
     public @Nullable Double min;
     public @Nullable Double max;
     public @Nullable List<String> range;


### PR DESCRIPTION
Allow schemas to provide labels for Channels and if none is provided map the code to something reasonably presentable.

It may seem like Channel labels are something of an internal detail in openHAB but they are used in generating the default names of linked Items and thence to places likely to be exposed to users.